### PR TITLE
Override docker image labels

### DIFF
--- a/pulsar-operator/src/main/resources/application.properties
+++ b/pulsar-operator/src/main/resources/application.properties
@@ -36,4 +36,11 @@ quarkus.operator-sdk.crd.apply=true
 # skip generating rbac since we manage it ourselves
 quarkus.kubernetes-client.generate-rbac=false
 
+## kubernetes extension options
+# These options affect the generated kubernetes manifests under target/kubernetes.yml. that are used by integration tests.
+
+# "Never" because the dev image should already be available locally
+quarkus.kubernetes.image-pull-policy=Never
+quarkus.kubernetes.service-account=pulsar-operator
+
 


### PR DESCRIPTION
Fixes #39

Now we override some labels such as mantainer, vendor, name... 
```
{
  "architecture": "x86_64",
  "build-date": "2023-01-18T09:50:53",
  "com.redhat.component": "openjdk-17-runtime-ubi8-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "DataStax Kubernetes Operator for Apache Pulsar",
  "distribution-scope": "public",
  "io.buildah.version": "1.27.1",
  "io.cekit.version": "3.11.0",
  "io.k8s.description": "Platform for running plain Java applications (fat-jar and flat classpath)",
  "io.k8s.display-name": "Java Applications",
  "io.openshift.expose-services": "",
  "io.openshift.tags": "java",
  "maintainer": "DataStax, Inc <info@datastax.com>",
  "name": "lunastreaming-operator",
  "org.jboss.product": "openjdk",
  "org.jboss.product.openjdk.version": "17",
  "org.jboss.product.version": "17",
  "release": "9",
  "summary": "DataStax Kubernetes Operator for Apache Pulsar",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/openjdk-17-runtime/images/1.14-9",
  "usage": "https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_java_s2i_for_openshift/",
  "vcs-ref": "043854ec5a8a145469c0504968ee45e7c1566392",
  "vcs-type": "git",
  "vendor": "DataStax, Inc",
  "version": "1.14"
}
```

I get the values from k8ssandra cass-operator: https://hub.docker.com/layers/k8ssandra/cass-operator/latest/images/sha256-9d3ea98c2cca01ee08cadf6e79e4167398b5095787afe6447c05abf763717f44?context=explore 


The io.k8s and io.openshift.* are related to openshift envinroment (https://docs.openshift.com/container-platform/3.11/creating_images/metadata.html) and I don't think they are problematic.
