### PR TITLE
Fix cluster status when setting replicas=0

### DIFF
--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/autorecovery/AutorecoveryController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/autorecovery/AutorecoveryController.java
@@ -65,6 +65,12 @@ public class AutorecoveryController extends AbstractController<Autorecovery> {
 
     private ReconciliationResult checkReady(Autorecovery resource,
                                             AutorecoveryResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final Deployment deployment = resourcesFactory.getDeployment();
         if (deployment == null) {
             patchAll(resourcesFactory);

--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/bastion/BastionController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/bastion/BastionController.java
@@ -64,6 +64,12 @@ public class BastionController extends AbstractController<Bastion> {
 
     private ReconciliationResult checkReady(Bastion resource,
                                             BastionResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final Deployment deployment = resourcesFactory.getDeployment();
         if (deployment == null) {
             patchAll(resourcesFactory);

--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/bookkeeper/BookKeeperController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/bookkeeper/BookKeeperController.java
@@ -58,6 +58,12 @@ public class BookKeeperController extends AbstractController<BookKeeper> {
 
     private ReconciliationResult checkReady(BookKeeper resource,
                                             BookKeeperResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final StatefulSet statefulSet = resourcesFactory.getStatefulSet();
         if (statefulSet == null) {
             patchAll(resourcesFactory);

--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/broker/BrokerController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/broker/BrokerController.java
@@ -67,6 +67,12 @@ public class BrokerController extends AbstractController<Broker> {
 
     private ReconciliationResult checkReady(Broker resource,
                                             BrokerResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final StatefulSet sts = resourcesFactory.getStatefulSet();
         if (sts == null) {
             patchAll(resourcesFactory);

--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/proxy/ProxyController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/proxy/ProxyController.java
@@ -68,6 +68,12 @@ public class ProxyController extends AbstractController<Proxy> {
 
     private ReconciliationResult checkReady(Proxy resource,
                                             ProxyResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final Deployment deployment = resourcesFactory.getDeployment();
         if (deployment == null) {
             patchAll(resourcesFactory);

--- a/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/zookeeper/ZooKeeperController.java
+++ b/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/controllers/zookeeper/ZooKeeperController.java
@@ -71,6 +71,12 @@ public class ZooKeeperController extends AbstractController<ZooKeeper> {
 
     private ReconciliationResult checkReady(ZooKeeper resource,
                                             ZooKeeperResourcesFactory resourcesFactory) {
+        if (!resourcesFactory.isComponentEnabled()) {
+            return new ReconciliationResult(
+                    false,
+                    List.of(createReadyConditionDisabled(resource))
+            );
+        }
         final StatefulSet sts = resourcesFactory.getStatefulSet();
         if (sts == null) {
             patchAll(resourcesFactory);

--- a/tests/src/test/java/com/datastax/oss/pulsaroperator/tests/ScalingTest.java
+++ b/tests/src/test/java/com/datastax/oss/pulsaroperator/tests/ScalingTest.java
@@ -73,6 +73,16 @@ public class ScalingTest extends BasePulsarClusterTest {
                             && s.getStatus().getReadyReplicas() == 3, DEFAULT_AWAIT_SECONDS, TimeUnit.SECONDS);
 
             assertProduceConsume();
+
+            specs.getBroker().setReplicas(0);
+            specs.getFunctionsWorker().setReplicas(0);
+            specs.getZookeeper().setReplicas(0);
+            specs.getBookkeeper().setReplicas(0);
+            specs.getBastion().setReplicas(0);
+            specs.getProxy().setReplicas(0);
+            specs.getAutorecovery().setReplicas(0);
+            applyPulsarCluster(specsToYaml(specs));
+
         } catch (Throwable t) {
             log.error("test failed with {}", t.getMessage(), t);
             printAllPodsLogs();


### PR DESCRIPTION
The cluster status never reach Ready=True if replicas for a specific component is set to zero.
This cause the operator to not correctly upgrade all the components.