### PR TITLE
Fix documentation of diskUsageTolerance thresholds

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14129,7 +14129,7 @@ Autoscaling config.
         <td><b>diskUsageToleranceHwm</b></td>
         <td>number</td>
         <td>
-          The threshold to trigger a scale down. The autoscaler will scale down if all the bookies' disk usage is lower than this threshold. Default is '0.92'<br/>
+          The threshold to trigger a scale up. The autoscaler will scale up if any of thebookie's disk usage is higher than or equal to this threshold. Default is '0.92'<br/>
           <br/>
             <i>Minimum</i>: 0<br/>
             <i>Maximum</i>: 1<br/>
@@ -14139,7 +14139,7 @@ Autoscaling config.
         <td><b>diskUsageToleranceLwm</b></td>
         <td>number</td>
         <td>
-          The threshold to trigger a scale up. The autoscaler will scale up if all the bookies' disk usage is higher than this threshold. Default is '0.75'<br/>
+          The threshold to trigger a scale down. The autoscaler will scale down if all the bookies' disk usage is lower than this threshold. Default is '0.75'<br/>
           <br/>
             <i>Minimum</i>: 0<br/>
             <i>Maximum</i>: 1<br/>
@@ -20706,7 +20706,7 @@ Autoscaling config.
         <td><b>diskUsageToleranceHwm</b></td>
         <td>number</td>
         <td>
-          The threshold to trigger a scale down. The autoscaler will scale down if all the bookies' disk usage is lower than this threshold. Default is '0.92'<br/>
+          The threshold to trigger a scale up. The autoscaler will scale up if any of thebookie's disk usage is higher than or equal to this threshold. Default is '0.92'<br/>
           <br/>
             <i>Minimum</i>: 0<br/>
             <i>Maximum</i>: 1<br/>
@@ -20716,7 +20716,7 @@ Autoscaling config.
         <td><b>diskUsageToleranceLwm</b></td>
         <td>number</td>
         <td>
-          The threshold to trigger a scale up. The autoscaler will scale up if all the bookies' disk usage is higher than this threshold. Default is '0.75'<br/>
+          The threshold to trigger a scale down. The autoscaler will scale down if all the bookies' disk usage is lower than this threshold. Default is '0.75'<br/>
           <br/>
             <i>Minimum</i>: 0<br/>
             <i>Maximum</i>: 1<br/>

--- a/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
@@ -725,9 +725,10 @@ spec:
                               minimum: 1000.0
                               type: integer
                             diskUsageToleranceLwm:
-                              description: The threshold to trigger a scale up. The
-                                autoscaler will scale up if all the bookies' disk
-                                usage is higher than this threshold. Default is '0.75'
+                              description: The threshold to trigger a scale down.
+                                The autoscaler will scale down if all the bookies'
+                                disk usage is lower than this threshold. Default is
+                                '0.75'
                               maximum: 1.0
                               minimum: 0.0
                               type: number
@@ -738,10 +739,10 @@ spec:
                               minimum: 1.0
                               type: integer
                             diskUsageToleranceHwm:
-                              description: The threshold to trigger a scale down.
-                                The autoscaler will scale down if all the bookies'
-                                disk usage is lower than this threshold. Default is
-                                '0.92'
+                              description: The threshold to trigger a scale up. The
+                                autoscaler will scale up if any of thebookie's disk
+                                usage is higher than or equal to this threshold. Default
+                                is '0.92'
                               maximum: 1.0
                               minimum: 0.0
                               type: number
@@ -2904,9 +2905,9 @@ spec:
                         minimum: 1000.0
                         type: integer
                       diskUsageToleranceLwm:
-                        description: The threshold to trigger a scale up. The autoscaler
-                          will scale up if all the bookies' disk usage is higher than
-                          this threshold. Default is '0.75'
+                        description: The threshold to trigger a scale down. The autoscaler
+                          will scale down if all the bookies' disk usage is lower
+                          than this threshold. Default is '0.75'
                         maximum: 1.0
                         minimum: 0.0
                         type: number
@@ -2917,9 +2918,9 @@ spec:
                         minimum: 1.0
                         type: integer
                       diskUsageToleranceHwm:
-                        description: The threshold to trigger a scale down. The autoscaler
-                          will scale down if all the bookies' disk usage is lower
-                          than this threshold. Default is '0.92'
+                        description: The threshold to trigger a scale up. The autoscaler
+                          will scale up if any of thebookie's disk usage is higher
+                          than or equal to this threshold. Default is '0.92'
                         maximum: 1.0
                         minimum: 0.0
                         type: number

--- a/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
@@ -15904,9 +15904,10 @@ spec:
                               minimum: 1000.0
                               type: integer
                             diskUsageToleranceLwm:
-                              description: The threshold to trigger a scale up. The
-                                autoscaler will scale up if all the bookies' disk
-                                usage is higher than this threshold. Default is '0.75'
+                              description: The threshold to trigger a scale down.
+                                The autoscaler will scale down if all the bookies'
+                                disk usage is lower than this threshold. Default is
+                                '0.75'
                               maximum: 1.0
                               minimum: 0.0
                               type: number
@@ -15917,10 +15918,10 @@ spec:
                               minimum: 1.0
                               type: integer
                             diskUsageToleranceHwm:
-                              description: The threshold to trigger a scale down.
-                                The autoscaler will scale down if all the bookies'
-                                disk usage is lower than this threshold. Default is
-                                '0.92'
+                              description: The threshold to trigger a scale up. The
+                                autoscaler will scale up if any of thebookie's disk
+                                usage is higher than or equal to this threshold. Default
+                                is '0.92'
                               maximum: 1.0
                               minimum: 0.0
                               type: number
@@ -18083,9 +18084,9 @@ spec:
                         minimum: 1000.0
                         type: integer
                       diskUsageToleranceLwm:
-                        description: The threshold to trigger a scale up. The autoscaler
-                          will scale up if all the bookies' disk usage is higher than
-                          this threshold. Default is '0.75'
+                        description: The threshold to trigger a scale down. The autoscaler
+                          will scale down if all the bookies' disk usage is lower
+                          than this threshold. Default is '0.75'
                         maximum: 1.0
                         minimum: 0.0
                         type: number
@@ -18096,9 +18097,9 @@ spec:
                         minimum: 1.0
                         type: integer
                       diskUsageToleranceHwm:
-                        description: The threshold to trigger a scale down. The autoscaler
-                          will scale down if all the bookies' disk usage is lower
-                          than this threshold. Default is '0.92'
+                        description: The threshold to trigger a scale up. The autoscaler
+                          will scale up if any of thebookie's disk usage is higher
+                          than or equal to this threshold. Default is '0.92'
                         maximum: 1.0
                         minimum: 0.0
                         type: number

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoscalerSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoscalerSpec.java
@@ -40,15 +40,15 @@ public class BookKeeperAutoscalerSpec {
     // should be around bookie's diskUsageWarnThreshold + diskUsageLwmThreshold / 2
     @Min(0.0d)
     @Max(1.0d)
-    @JsonPropertyDescription("The threshold to trigger a scale down. The autoscaler will scale down if all the "
-            + "bookies' disk usage is lower than this threshold. Default is '0.92'")
+    @JsonPropertyDescription("The threshold to trigger a scale up. The autoscaler will scale up if any of the"
+            + "bookie's disk usage is higher than or equal to this threshold. Default is '0.92'")
     Double diskUsageToleranceHwm;
 
     // should be around bookie's diskUsageLwmThreshold or below
     @Min(0.0d)
     @Max(1.0d)
-    @JsonPropertyDescription("The threshold to trigger a scale up. The autoscaler will scale up if all the "
-            + "bookies' disk usage is higher than this threshold. Default is '0.75'")
+    @JsonPropertyDescription("The threshold to trigger a scale down. The autoscaler will scale down if all the "
+            + "bookies' disk usage is lower than this threshold. Default is '0.75'")
     Double diskUsageToleranceLwm;
 
     @Min(1)


### PR DESCRIPTION
The semantics of `diskUsageToleranceHwm` is:
> For all bookies s.t. disk_usage < `diskUsageToleranceHwm` -> `diskNotAtRisk` > 0 -> `diskNotAtRisk` != 0 -> `atRiskWritableBookies` == 0 -> steady state -> no scale up
Exists bookie(i) s.t. disk_usage(i) >= `diskUsageToleranceHwm` -> `diskNotAtRisk` == 0 -> `atRiskWritableBookies` > 0 -> scale up

from [https://github.com/riptano/pulsar-operator/blob/0e0368657148dad95d45659de96eea3f12[…]stax/oss/pulsaroperator/autoscaler/BookKeeperSetAutoscaler.java](https://github.com/riptano/pulsar-operator/blob/0e0368657148dad95d45659de96eea3f12fb154f/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/autoscaler/BookKeeperSetAutoscaler.java#L261-L274)

The semantics of `diskUsageToleranceLwm` is:
> Exists bookie(i) s.t. disk_usage(i) > `diskUsageToleranceLwm` -> `notReadyDiskCount` != 0 -> steady state -> no scale down
For all bookies s.t. disk_usage <= `diskUsageToleranceLwm` -> `notReadyDiskCount` == 0 -> scale down

from [https://github.com/riptano/pulsar-operator/blob/0e0368657148dad95d45659de96eea3f12[…]stax/oss/pulsaroperator/autoscaler/BookKeeperSetAutoscaler.java](https://github.com/riptano/pulsar-operator/blob/0e0368657148dad95d45659de96eea3f12fb154f/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/autoscaler/BookKeeperSetAutoscaler.java#L225-L245)

I verified on a running cluster that this semantics holds. These are the steps I run:

1. fill bookie(i)'s ledger disk up to du_i, s.t. `diskUsageToleranceHwm` <= du_i < 0.95 == [`diskUsageThreshold`](https://bookkeeper.apache.org/docs/reference/config/#disk-utilization)
2. observe operator scaling up and showing a bookie is `writableAtRisk` (-> test [this non-trivial branch](https://github.com/riptano/pulsar-operator/blob/0e0368657148dad95d45659de96eea3f12fb154f/pulsar-operator/src/main/java/com/datastax/oss/pulsaroperator/autoscaler/BookKeeperSetAutoscaler.java#L171-L177))
3. flush the data and observe metrics for the stabilisation period
4. operator scales down