### PR TITLE
Add proxyRoles config to function worker configmap

### DIFF
--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -58,7 +58,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         assertValue(outputDir);
-        assertDiff(diff, 160);
+        assertDiff(diff, 161);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         final PulsarCluster pulsar = getPulsarClusterFromOutputdir(outputDir);
-        assertDiff(diff, 151);
+        assertDiff(diff, 152);
         Assert.assertEquals(pulsar.getSpec().getBastion().getReplicas(), 0);
     }
 

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -244,6 +244,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
                             "org.apache.pulsar.broker.authentication.AuthenticationProviderTls"));
             data.put("clientAuthenticationPlugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
             data.put("clientAuthenticationParameters", "file:///pulsar/token-superuser/superuser.jwt");
+            data.put("proxyRoles", tokenConfig.getProxyRoles());
             data.put("superUserRoles", new TreeSet<>(tokenConfig.getSuperUserRoles()));
             data.put("properties", Map.of(
                     "tokenPublicKey", "file:///pulsar/token-public-key/%s".formatted(tokenConfig.getPublicKeyFile())

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
@@ -814,6 +814,7 @@ public class FunctionsWorkerControllerTest {
         expectedData.put("authorizationProvider", "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider");
         expectedData.put("clientAuthenticationPlugin", "org.apache.pulsar.client.impl.auth.AuthenticationToken");
         expectedData.put("clientAuthenticationParameters", "file:///pulsar/token-superuser/superuser.jwt");
+        expectedData.put("proxyRoles", List.of("proxy"));
         expectedData.put("superUserRoles", List.of("admin", "proxy", "superuser", "websocket"));
         expectedData.put("properties", Map.of(
                 "tokenPublicKey", "file:///pulsar/token-public-key/my-public.key")


### PR DESCRIPTION
With the addition of https://github.com/apache/pulsar/pull/19975, the function worker needs the `proxyRoles` configuration. This PR adds that configuration to the function worker's config map.