### PR TITLE
Do not mount token private key to proxy pod containers

### DIFF
--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -74,7 +74,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         final PulsarCluster pulsar = getPulsarClusterFromOutputdir(outputDir);
-        assertDiff(diff, 122);
+        assertDiff(diff, 123);
         Assert.assertEquals(pulsar.getSpec().getFunctionsWorker().getReplicas(), 0);
     }
 
@@ -91,7 +91,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         final PulsarCluster pulsar = getPulsarClusterFromOutputdir(outputDir);
-        assertDiff(diff, 151);
+        assertDiff(diff, 152);
         Assert.assertEquals(pulsar.getSpec().getBastion().getReplicas(), 0);
     }
 
@@ -707,8 +707,6 @@ public class PulsarClusterResourceGeneratorTest {
                                 value: pulsar://pulsar-cluster-broker:6650
                               - name: PulsarPublicKey
                                 value: /pulsar/token-public-key/pulsar-public.key
-                              - name: PulsarPrivateKey
-                                value: /pulsar/token-private-key/pulsar-private.key
                               - name: CertFile
                                 value: /pulsar/certs/tls.crt
                               - name: KeyFile
@@ -749,9 +747,6 @@ public class PulsarClusterResourceGeneratorTest {
                               volumeMounts:
                               - mountPath: /pulsar/certs
                                 name: certs
-                                readOnly: true
-                              - mountPath: /pulsar/token-private-key
-                                name: token-private-key
                                 readOnly: true
                               - mountPath: /pulsar/token-public-key
                                 name: token-public-key

--- a/migration-tool/src/test/resources/pulsar-helm-chart/base-release/deployment-pulsar-cluster-proxy.yaml
+++ b/migration-tool/src/test/resources/pulsar-helm-chart/base-release/deployment-pulsar-cluster-proxy.yaml
@@ -207,8 +207,6 @@ spec:
           value: pulsar://pulsar-cluster-broker:6650
         - name: PulsarPublicKey
           value: /pulsar/token-public-key/pulsar-public.key
-        - name: PulsarPrivateKey
-          value: /pulsar/token-private-key/pulsar-private.key
         - name: CertFile
           value: /pulsar/certs/tls.crt
         - name: KeyFile

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
@@ -400,7 +400,6 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
         }
         if (isAuthTokenEnabled()) {
             addSecretTokenVolume(volumeMounts, volumes, "public-key");
-            addSecretTokenVolume(volumeMounts, volumes, "private-key");
             addSecretTokenVolume(volumeMounts, volumes, "proxy");
             addSecretTokenVolume(volumeMounts, volumes, "websocket");
             addSecretTokenVolume(volumeMounts, volumes, "superuser");


### PR DESCRIPTION
The pulsar proxy does not need the token private key. It is mounted in the DataStax Helm Chart for Pulsar for legacy reasons related to Pulsar Beam and Burnell, but those are no longer relevant.