### PR TITLE
Fix tls ports for FunctionWorkers and Zookeeper

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -299,7 +299,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
                         "pulsarRootDir", "/pulsar",
                         "submittingInsidePod", true,
                         "pulsarServiceUrl", brokerServiceUrl,
-                        "pulsarAdminUrl", "https://%s.%s:6750/"
+                        "pulsarAdminUrl", "https://%s.%s:6751/"
                                 .formatted(resourceName, getServiceDnsSuffix()),
                         "percentMemoryPadding", 10)
                 );

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -61,7 +61,7 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
     public static final int DEFAULT_SERVER_PORT = 2888;
     public static final int DEFAULT_LEADER_ELECTION_PORT = 3888;
     public static final int DEFAULT_CLIENT_PORT = 2181;
-    public static final int DEFAULT_CLIENT_TLS_PORT = 2281;
+    public static final int DEFAULT_CLIENT_TLS_PORT = 2282;
     public static final String ENV_ZOOKEEPER_SERVERS = "ZOOKEEPER_SERVERS";
     public static final List<String> DEFAULT_ENV = List.of("ZOOKEEPER_SERVERS");
 


### PR DESCRIPTION
Haxx tests discovered issues running function workers with the kaap operator and also some issues have started to appear with running pulsar 3.0 and master tests using the kaap operator and tls.

See:
1. https://datastax.jira.com/browse/LS-1192
2 https://datastax.jira.com/browse/LS-1149

This is a naive attempt to fix the issue, but it is not tested.