### PR TITLE
Migration tool: strip out runtime k8s annotations

### DIFF
--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/diff/DiffChecker.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/diff/DiffChecker.java
@@ -287,10 +287,11 @@ public class DiffChecker {
         metadata.remove("finalizers");
         final Map<String, Object> annotations = getPropAsMap(metadata, "annotations");
         if (annotations != null) {
-            BaseSpecGenerator.HELM_ANNOTATIONS.forEach(annotations::remove);
-            annotations.remove("deployment.kubernetes.io/revision");
-            if (annotations.isEmpty()) {
+            final Map<String, String> newAnnotations = BaseSpecGenerator.cleanupAnnotations(annotations);
+            if (newAnnotations.isEmpty()) {
                 metadata.remove("annotations");
+            } else {
+                metadata.put("annotations", newAnnotations);
             }
         }
     }

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/AutorecoverySpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/AutorecoverySpecGenerator.java
@@ -90,8 +90,8 @@ public class AutorecoverySpecGenerator extends BaseSpecGenerator<AutorecoverySpe
         final NodeAffinity nodeAffinity = spec.getAffinity() == null ? null : spec.getAffinity().getNodeAffinity();
         final Map<String, String> matchLabels = getMatchLabels(deploymentSpec.getSelector());
         generatedSpec = AutorecoverySpec.builder()
-                .annotations(deployment.getMetadata().getAnnotations())
-                .podAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(deployment.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(container.getImage())
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BaseSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BaseSpecGenerator.java
@@ -54,11 +54,6 @@ import java.util.stream.Collectors;
 
 public abstract class BaseSpecGenerator<T> {
 
-    public static final List<String> HELM_ANNOTATIONS = List.of(
-            "meta.helm.sh/release-name",
-            "meta.helm.sh/release-namespace"
-    );
-
     public static final List<String> HELM_LABELS = List.of(
             "app.kubernetes.io/managed-by",
             "chart",
@@ -422,6 +417,34 @@ public abstract class BaseSpecGenerator<T> {
         }
         return initContainers.stream().filter(e -> !excludes.contains(e.getName()))
                 .collect(Collectors.toList());
+    }
+
+
+    public static Map<String, String> cleanupAnnotations(Map<String, ?> annotations) {
+        if (annotations == null) {
+            return Map.of();
+        }
+        return annotations.entrySet()
+                        .stream()
+                        .filter(e -> keepAnnotation(e))
+                        .collect(Collectors.toMap(Map.Entry::getKey, e -> String.valueOf(e.getValue())));
+    }
+
+    private static boolean keepAnnotation(Map.Entry<String, ?> e) {
+        final String key = e.getKey();
+        if (key.equals("checksum/config")) {
+            return false;
+        }
+        if (key.startsWith("kubectl.")) {
+            return false;
+        }
+        if (key.startsWith("meta.helm.sh/")) {
+            return false;
+        }
+        if (key.startsWith("deployment.kubernetes.io")) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BastionSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BastionSpecGenerator.java
@@ -92,8 +92,8 @@ public class BastionSpecGenerator extends BaseSpecGenerator<BastionSpec> {
         final NodeAffinity nodeAffinity = spec.getAffinity() == null ? null : spec.getAffinity().getNodeAffinity();
         final Map<String, String> matchLabels = getMatchLabels(deploymentSpec.getSelector());
         generatedSpec = BastionSpec.builder()
-                .annotations(deployment.getMetadata().getAnnotations())
-                .podAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(deployment.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(container.getImage())
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BookKeeperSetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BookKeeperSetSpecGenerator.java
@@ -111,8 +111,8 @@ public class BookKeeperSetSpecGenerator extends BaseSpecGenerator<BookKeeperSetS
         final PersistentVolumeClaim journalPvc = requirePvc("%s-journal".formatted(resourceName), volumeClaimTemplates);
         final PersistentVolumeClaim ledgersPvc = requirePvc("%s-ledgers".formatted(resourceName), volumeClaimTemplates);
         generatedSpec = BookKeeperSetSpec.builder()
-                .annotations(statefulSet.getMetadata().getAnnotations())
-                .podAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(statefulSet.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(container.getImage())
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BrokerSetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BrokerSetSpecGenerator.java
@@ -114,8 +114,8 @@ public class BrokerSetSpecGenerator extends BaseSpecGenerator<BrokerSetSpec> {
 
 
         generatedSpec = BrokerSetSpec.builder()
-                .annotations(statefulSet.getMetadata().getAnnotations())
-                .podAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(statefulSet.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(container.getImage())
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
@@ -212,7 +212,7 @@ public class BrokerSetSpecGenerator extends BaseSpecGenerator<BrokerSetSpec> {
             annotations = new HashMap<>();
         }
         return BrokerSetSpec.ServiceConfig.builder()
-                .annotations(annotations)
+                .annotations(cleanupAnnotations(annotations))
                 .additionalPorts(removeServicePorts(service.getSpec().getPorts(),
                         BrokerResourcesFactory.DEFAULT_HTTP_PORT,
                         BrokerResourcesFactory.DEFAULT_HTTPS_PORT,

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/FunctionsWorkerSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/FunctionsWorkerSpecGenerator.java
@@ -115,8 +115,8 @@ public class FunctionsWorkerSpecGenerator extends BaseSpecGenerator<FunctionsWor
         }
 
         generatedSpec = FunctionsWorkerSpec.builder()
-                .annotations(statefulSet.getMetadata().getAnnotations())
-                .podAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(statefulSet.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(mainContainer.getImage())
                 .imagePullPolicy(mainContainer.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ProxySetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ProxySetSpecGenerator.java
@@ -116,8 +116,8 @@ public class ProxySetSpecGenerator extends BaseSpecGenerator<ProxySetSpec> {
         final Map<String, String> matchLabels = getMatchLabels(deploymentSpec.getSelector());
         generatedSpec = ProxySetSpec.builder()
                 .overrideResourceName(proxyInputSpecs.getOverrideName())
-                .annotations(deployment.getMetadata().getAnnotations())
-                .podAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(deployment.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(deploymentSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(mainContainer.getImage())
                 .imagePullPolicy(mainContainer.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
@@ -218,7 +218,7 @@ public class ProxySetSpecGenerator extends BaseSpecGenerator<ProxySetSpec> {
         boolean hasPlainTextPort = service.getSpec().getPorts().stream()
                 .filter(p -> p.getPort() == ProxyResourcesFactory.DEFAULT_HTTP_PORT).findFirst().isPresent();
         return ProxySetSpec.ServiceConfig.builder()
-                .annotations(annotations)
+                .annotations(cleanupAnnotations(annotations))
                 .additionalPorts(removeServicePorts(service.getSpec().getPorts(),
                         ProxyResourcesFactory.DEFAULT_HTTP_PORT,
                         ProxyResourcesFactory.DEFAULT_HTTPS_PORT,

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ZooKeeperSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ZooKeeperSpecGenerator.java
@@ -108,8 +108,8 @@ public class ZooKeeperSpecGenerator extends BaseSpecGenerator<ZooKeeperSpec> {
         final NodeAffinity nodeAffinity = spec.getAffinity() == null ? null : spec.getAffinity().getNodeAffinity();
         final Map<String, String> matchLabels = getMatchLabels(statefulSetSpec);
         generatedSpec = ZooKeeperSpec.builder()
-                .annotations(statefulSet.getMetadata().getAnnotations())
-                .podAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations())
+                .annotations(cleanupAnnotations(statefulSet.getMetadata().getAnnotations()))
+                .podAnnotations(cleanupAnnotations(statefulSetSpec.getTemplate().getMetadata().getAnnotations()))
                 .image(container.getImage())
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
@@ -204,7 +204,7 @@ public class ZooKeeperSpecGenerator extends BaseSpecGenerator<ZooKeeperSpec> {
         }
         annotations.remove("service.alpha.kubernetes.io/tolerate-unready-endpoints");
         return ZooKeeperSpec.ServiceConfig.builder()
-                .annotations(annotations)
+                .annotations(cleanupAnnotations(annotations))
                 .additionalPorts(
                         removeServicePorts(mainService.getSpec().getPorts(),
                                 ZooKeeperResourcesFactory.DEFAULT_CLIENT_PORT,

--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import javax.ws.rs.HEAD;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.Assert;
@@ -58,7 +59,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         assertValue(outputDir);
-        assertDiff(diff, 161);
+        assertDiff(diff, 159);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         final PulsarCluster pulsar = getPulsarClusterFromOutputdir(outputDir);
-        assertDiff(diff, 122);
+        assertDiff(diff, 120);
         Assert.assertEquals(pulsar.getSpec().getFunctionsWorker().getReplicas(), 0);
     }
 
@@ -189,12 +190,8 @@ public class PulsarClusterResourceGeneratorTest {
                                 required: true
                               zone:
                                 enabled: false
-                            annotations:
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: 95e7a9a97053b9160bd894c5c1fcdcb2f6783e2c19228f6677443a006b51eb19
-                              kubectl.kubernetes.io/restartedAt: 2022-04-12T21:56:19-04:00
                               prometheus.io/port: 8000
                               prometheus.io/scrape: "true"
                             labels:
@@ -256,8 +253,6 @@ public class PulsarClusterResourceGeneratorTest {
                               existingStorageClassName: pulsar-cluster-zookeeper-data
                             service:
                               annotations:
-                                meta.helm.sh/release-name: pulsar-cluster
-                                meta.helm.sh/release-namespace: pulsar
                                 publishNotReadyAddresses: "true"
                               additionalPorts: []
                             metadataInitializationJob:
@@ -277,12 +272,8 @@ public class PulsarClusterResourceGeneratorTest {
                                 required: false
                               zone:
                                 enabled: false
-                            annotations:
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: e45a01b57a5257d67a86fe0350096152e0d173fc27bcd87f03b0ddab8b10e3a2
-                              kubectl.kubernetes.io/restartedAt: 2021-11-01T15:53:51-04:00
                               prometheus.io/port: 8000
                               prometheus.io/scrape: "true"
                             labels:
@@ -437,12 +428,8 @@ public class PulsarClusterResourceGeneratorTest {
                                 required: false
                               zone:
                                 enabled: false
-                            annotations:
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: b5ed0b35c448ff4bb2aa18d4b436516875c4b5fb75d535c8cffe212202ecb289
-                              kubectl.kubernetes.io/restartedAt: 2023-01-18T16:02:36-05:00
                               prometheus.io/path: /metrics/
                               prometheus.io/port: 8080
                               prometheus.io/scrape: "true"
@@ -603,9 +590,7 @@ public class PulsarClusterResourceGeneratorTest {
                                 cpu: 1
                                 memory: 4Gi
                             service:
-                              annotations:
-                                meta.helm.sh/release-name: pulsar-cluster
-                                meta.helm.sh/release-namespace: pulsar
+                              annotations: {}
                               additionalPorts:
                               - name: kafkaplaintext
                                 port: 9092
@@ -645,12 +630,8 @@ public class PulsarClusterResourceGeneratorTest {
                                 required: false
                               zone:
                                 enabled: false
-                            annotations:
-                              deployment.kubernetes.io/revision: 138
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: cbb34e869a79e09b1db23364ccc46bf773b11b8376182b444ef48bfe08ecb238
                               prometheus.io/path: /metrics/
                               prometheus.io/port: 8080
                               prometheus.io/scrape: "true"
@@ -832,8 +813,6 @@ public class PulsarClusterResourceGeneratorTest {
                             service:
                               annotations:
                                 external-dns.alpha.kubernetes.io/hostname: pulsar-gcp-useast4.dev.streaming.datastax.com
-                                meta.helm.sh/release-name: pulsar-cluster
-                                meta.helm.sh/release-namespace: pulsar
                                 projectcontour.io/upstream-protocol.tls: "https,8964"
                               additionalPorts:
                               - name: wsstoken
@@ -916,12 +895,8 @@ public class PulsarClusterResourceGeneratorTest {
                               ensemblePlacementPolicy: ""
                               zkServers: pulsar-cluster-zookeeper-ca:2181
                             replicas: 1
-                            annotations:
-                              deployment.kubernetes.io/revision: 40
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: 91c2ed87c44f8d78c4ec549e7641f9e5082734f543ce9ace3b02b09607f9f56a
                               prometheus.io/port: 8000
                               prometheus.io/scrape: "true"
                             labels:
@@ -972,12 +947,8 @@ public class PulsarClusterResourceGeneratorTest {
                               authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationToken
                               tlsTrustCertsFilePath: /etc/ssl/certs/ca-certificates.crt
                             replicas: 1
-                            annotations:
-                              deployment.kubernetes.io/revision: 63
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
-                            podAnnotations:
-                              checksum/config: 53b418fa312fa81ac292dbca162ef0377bd7cedd4f0b730ac32a49ad8ff87e2a
+                            annotations: {}
+                            podAnnotations: {}
                             labels:
                               app: pulsar
                               app.kubernetes.io/managed-by: Helm
@@ -1030,12 +1001,8 @@ public class PulsarClusterResourceGeneratorTest {
                                 required: true
                               zone:
                                 enabled: false
-                            annotations:
-                              meta.helm.sh/release-name: pulsar-cluster
-                              meta.helm.sh/release-namespace: pulsar
+                            annotations: {}
                             podAnnotations:
-                              checksum/config: 47ad923e414693581ea4870abc26b5fc43b332ace809516acd9734b5ba5c7240
-                              kubectl.kubernetes.io/restartedAt: 2022-10-14T09:59:02-04:00
                               prometheus.io/port: 6750
                               prometheus.io/scrape: "true"
                             labels:

--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
-import javax.ws.rs.HEAD;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.Assert;


### PR DESCRIPTION
Fixes: https://github.com/datastax/kaap/issues/119


* Only keep and show annotations that are not related to k8s, kubectl or helm

```
private static boolean keepAnnotation(Map.Entry<String, ?> e) {
        final String key = e.getKey();
        if (key.equals("checksum/config")) {
            return false;
        }
        if (key.startsWith("kubectl.")) {
            return false;
        }
        if (key.startsWith("meta.helm.sh/")) {
            return false;
        }
        if (key.startsWith("deployment.kubernetes.io")) {
            return false;
        }
        return true;
    }
```