### PR TITLE
Fix prometheus scrape ports

### DIFF
--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -58,7 +58,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         assertValue(outputDir);
-        assertDiff(diff, 161);
+        assertDiff(diff, 159);
     }
 
     @Test
@@ -74,7 +74,7 @@ public class PulsarClusterResourceGeneratorTest {
         final DiffCollectorOutputWriter diff = generate(client, tmpDir);
         final File outputDir = new File(tmpDir.toFile(), CONTEXT);
         final PulsarCluster pulsar = getPulsarClusterFromOutputdir(outputDir);
-        assertDiff(diff, 122);
+        assertDiff(diff, 120);
         Assert.assertEquals(pulsar.getSpec().getFunctionsWorker().getReplicas(), 0);
     }
 

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
@@ -687,10 +687,13 @@ public abstract class BaseResourcesFactory<T> {
 
     protected Map<String, String> getPodAnnotations(
             Map<String, String> customPodAnnotations,
-            ConfigMap configMap) {
+            ConfigMap configMap,
+            String prometheusPort) {
         Map<String, String> annotations = new HashMap<>();
-        annotations.put("prometheus.io/scrape", "true");
-        annotations.put("prometheus.io/port", "8080");
+        if (prometheusPort != null) {
+            annotations.put("prometheus.io/scrape", "true");
+            annotations.put("prometheus.io/port", prometheusPort);
+        }
         if (customPodAnnotations != null) {
             annotations.putAll(customPodAnnotations);
         }

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryResourcesFactory.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.kaap.controllers.autorecovery;
 
 import com.datastax.oss.kaap.controllers.BaseResourcesFactory;
+import com.datastax.oss.kaap.controllers.bookkeeper.BookKeeperResourcesFactory;
 import com.datastax.oss.kaap.crds.GlobalSpec;
 import com.datastax.oss.kaap.crds.autorecovery.AutorecoverySpec;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -127,7 +128,8 @@ public class AutorecoveryResourcesFactory extends BaseResourcesFactory<Autorecov
         Map<String, String> labels = getLabels(spec.getLabels());
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap,
+                BookKeeperResourcesFactory.DEFAULT_HTTP_PORT + "");
         final Map<String, String> annotations = getAnnotations(spec.getAnnotations());
 
         List<VolumeMount> volumeMounts = new ArrayList<>();

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
@@ -124,7 +124,7 @@ public class BastionResourcesFactory extends BaseResourcesFactory<BastionSpec> {
         Map<String, String> labels = getLabels(spec.getLabels());
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, null);
         final Map<String, String> annotations = getAnnotations(spec.getAnnotations());
 
         List<VolumeMount> volumeMounts = new ArrayList<>();

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperResourcesFactory.java
@@ -216,7 +216,7 @@ public class BookKeeperResourcesFactory extends BaseResourcesFactory<BookKeeperS
         Map<String, String> labels = getLabels(spec.getLabels());
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, DEFAULT_HTTP_PORT + "");
         final Map<String, String> annotations = getAnnotations(spec.getAnnotations());
 
 

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
@@ -314,7 +314,7 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
         Map<String, String> labels = getLabels(spec.getLabels());
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, DEFAULT_HTTP_PORT + "");
         Map<String, String> annotations = getAnnotations(spec.getAnnotations());
 
         List<VolumeMount> volumeMounts = new ArrayList<>();
@@ -496,7 +496,7 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
                 .withNewSpec()
                 .withNewTemplate()
                 .withNewMetadata()
-                .withAnnotations(getPodAnnotations(spec.getPodAnnotations(), null))
+                .withAnnotations(getPodAnnotations(spec.getPodAnnotations(), null, null))
                 .withLabels(getPodLabels(spec.getPodLabels()))
                 .endMetadata()
                 .withNewSpec()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -358,7 +358,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
         Map<String, String> annotations = getAnnotations(spec.getAnnotations());
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, 8080 + "");
         Objects.requireNonNull(extraConfigMap, "ConfigMap (extra) should have been created at this point");
         addConfigMapChecksumAnnotation(extraConfigMap, podAnnotations);
 

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
@@ -334,7 +334,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
             data.put("brokerClientAuthenticationParameters", "file:///pulsar/token-websocket/websocket.jwt");
         }
         if (isTlsEnabledOnProxySet(proxySet)) {
-            data.put("webServicePortTls", "8001");
+            data.put("webServicePortTls", DEFAULT_WSS_PORT + "");
             data.put("tlsEnabled", "true");
             data.put("tlsCertificateFilePath", "/pulsar/certs/tls.crt");
             data.put("tlsKeyFilePath", "/pulsar/tls-pk8.key");
@@ -351,7 +351,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
 
         appendConfigData(data, webSocketConfig.getConfig());
         if (!data.containsKey("webServicePort")) {
-            data.put("webServicePort", "8000");
+            data.put("webServicePort", DEFAULT_WS_PORT + "");
         }
 
         final ConfigMap configMap = new ConfigMapBuilder()
@@ -385,7 +385,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
         Map<String, String> labels = getLabels(spec.getLabels());
         Map<String, String> podLabels = getPodLabels(spec.getPodLabels());
         Map<String, String> annotations = getAnnotations(spec.getAnnotations());
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, DEFAULT_HTTP_PORT + "");
         if (spec.getWebSocket().getEnabled()) {
             Objects.requireNonNull(wsConfigMap, "WsConfigMap should have been created at this point");
             addConfigMapChecksumAnnotation(wsConfigMap, podAnnotations);
@@ -570,8 +570,8 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
                 ? "-H \"Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\\r')\"" : "";
         return newProbeBuilder(specProbe)
                 .withNewExec()
-                .withCommand("sh", "-c", "curl -s --max-time %d --fail %s http://localhost:8080/metrics/ > /dev/null"
-                        .formatted(specProbe.getTimeoutSeconds(), authHeader))
+                .withCommand("sh", "-c", "curl -s --max-time %d --fail %s http://localhost:%d/metrics/ > /dev/null"
+                        .formatted(specProbe.getTimeoutSeconds(), authHeader, DEFAULT_HTTP_PORT))
                 .endExec()
                 .build();
     }

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -238,7 +238,7 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
         Map<String, String> matchLabels = getMatchLabels(spec.getMatchLabels());
         Map<String, String> annotations = getAnnotations(spec.getAnnotations());
         Objects.requireNonNull(configMap, "ConfigMap should have been created at this point");
-        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap);
+        Map<String, String> podAnnotations = getPodAnnotations(spec.getPodAnnotations(), configMap, 8000 + "");
 
         PodDNSConfig dnsConfig = global.getDnsConfig();
         Map<String, String> nodeSelectors = spec.getNodeSelectors();

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryControllerTest.java
@@ -119,7 +119,7 @@ public class AutorecoveryControllerTest {
                   template:
                     metadata:
                       annotations:
-                        prometheus.io/port: 8080
+                        prometheus.io/port: 8000
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
@@ -340,7 +340,7 @@ public class AutorecoveryControllerTest {
                         .getResource().getSpec().getTemplate().getMetadata().getAnnotations(),
                 Map.of(
                         "prometheus.io/scrape", "true",
-                        "prometheus.io/port", "8080",
+                        "prometheus.io/port", "8000",
                         "annotation-2", "ann2-value"
                 )
         );

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
@@ -121,9 +121,6 @@ public class BastionControllerTest {
                       component: bastion
                   template:
                     metadata:
-                      annotations:
-                        prometheus.io/port: 8080
-                        prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
                         cluster: pulsarname
@@ -396,8 +393,6 @@ public class BastionControllerTest {
                 client.getCreatedResource(Deployment.class)
                         .getResource().getSpec().getTemplate().getMetadata().getAnnotations(),
                 Map.of(
-                        "prometheus.io/scrape", "true",
-                        "prometheus.io/port", "8080",
                         "annotation-2", "ann2-value"
                 )
         );

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperControllerTest.java
@@ -177,7 +177,7 @@ public class BookKeeperControllerTest {
                   template:
                     metadata:
                       annotations:
-                        prometheus.io/port: 8080
+                        prometheus.io/port: 8000
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
@@ -706,7 +706,7 @@ public class BookKeeperControllerTest {
                         .getResource().getSpec().getTemplate().getMetadata().getAnnotations(),
                 Map.of(
                         "prometheus.io/scrape", "true",
-                        "prometheus.io/port", "8080",
+                        "prometheus.io/port", "8000",
                         "annotation-2", "ann2-value"
                 )
         );

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
@@ -395,9 +395,6 @@ public class BrokerControllerTest {
                         spec:
                           template:
                             metadata:
-                              annotations:
-                                prometheus.io/port: 8080
-                                prometheus.io/scrape: "true"
                               labels:
                                 app: pulsar
                                 cluster: pul

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
@@ -137,7 +137,7 @@ public class ZooKeeperControllerTest {
                           template:
                             metadata:
                               annotations:
-                                prometheus.io/port: 8080
+                                prometheus.io/port: 8000
                                 prometheus.io/scrape: "true"
                               labels:
                                 app: pulsar
@@ -631,7 +631,7 @@ public class ZooKeeperControllerTest {
                         .getResource().getSpec().getTemplate().getMetadata().getAnnotations(),
                 Map.of(
                         "prometheus.io/scrape", "true",
-                        "prometheus.io/port", "8080",
+                        "prometheus.io/port", "8000",
                         "annotation-2", "ann2-value"
                 )
         );


### PR DESCRIPTION
Fixes: #108

Each component adds the prometheus label for scraping the port with value "8080". This value is incorrect for ZK, BK and autorecovery.

Changes:
* Modify the label for each component
* Removed the label for the bastion