### PR TITLE
Do not set default JVM settings

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
@@ -85,7 +85,6 @@ public class BastionResourcesFactory extends BaseResourcesFactory<BastionSpec> {
         data.put("brokerServiceUrl", brokerServiceUrl);
         data.put("webServiceUrl", webServiceUrl);
         data.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        data.put("PULSAR_GC", "-XX:+UseG1GC");
         data.put("PULSAR_LOG_LEVEL", "info");
         data.put("PULSAR_LOG_ROOT_LEVEL", "info");
         data.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
@@ -259,9 +259,8 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
 
         data.put("allowAutoTopicCreationType", "non-partitioned");
         data.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        data.put("PULSAR_GC", "-XX:+UseG1GC");
         data.put("PULSAR_LOG_LEVEL", "info");
         data.put("PULSAR_LOG_ROOT_LEVEL", "info");
         data.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -178,9 +178,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
     public void patchExtraConfigMap() {
 
         Map<String, String> data = new HashMap<>();
-        data.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError");
-        data.put("PULSAR_GC", "-XX:+UseG1GC");
+        data.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
         data.put("PULSAR_LOG_LEVEL", "info");
         data.put("PULSAR_LOG_ROOT_LEVEL", "info");
         data.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
@@ -54,9 +54,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
     public static final String PROXY_DEFAULT_SET = "proxy";
 
     private static final Map<String, String> DEFAULT_CONFIG_MAP =
-            Map.of("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g",
-                    "PULSAR_GC", "-XX:+UseG1GC",
-                    "PULSAR_LOG_LEVEL", "info",
+            Map.of("PULSAR_LOG_LEVEL", "info",
                     "PULSAR_LOG_ROOT_LEVEL", "info",
                     "PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info",
                     "numHttpServerThreads", "10"

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -187,8 +187,7 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
 
     public void patchConfigMap() {
         Map<String, String> data = new HashMap<>();
-        data.put("PULSAR_MEM", "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
-        data.put("PULSAR_GC", "-XX:+UseG1GC");
+        data.put("PULSAR_MEM", "-Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
         data.put("PULSAR_LOG_LEVEL", "info");
         data.put("PULSAR_LOG_ROOT_LEVEL", "info");
         data.put("PULSAR_EXTRA_OPTS",

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
@@ -85,7 +85,6 @@ public class BastionControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
                           PULSAR_MEM: -XX:+ExitOnOutOfMemoryError
@@ -184,7 +183,6 @@ public class BastionControllerTest {
         expectedData.put("PULSAR_PREFIX_brokerServiceUrl", "pulsar://pul-broker.ns.svc.cluster.local:6650/");
         expectedData.put("PULSAR_PREFIX_webServiceUrl", "http://pul-broker.ns.svc.cluster.local:8080/");
         expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "debug");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -214,7 +212,6 @@ public class BastionControllerTest {
         expectedData.put("PULSAR_PREFIX_brokerServiceUrl", "pulsar://pul-proxy.ns.svc.cluster.local:6650/");
         expectedData.put("PULSAR_PREFIX_webServiceUrl", "http://pul-proxy.ns.svc.cluster.local:8080/");
         expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -247,7 +244,6 @@ public class BastionControllerTest {
         expectedData.put("PULSAR_PREFIX_brokerServiceUrl", "pulsar+ssl://pul-broker.ns.svc.cluster.local:6651/");
         expectedData.put("PULSAR_PREFIX_webServiceUrl", "https://pul-broker.ns.svc.cluster.local:8443/");
         expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -289,7 +285,6 @@ public class BastionControllerTest {
         expectedData.put("PULSAR_PREFIX_brokerServiceUrl", "pulsar+ssl://pul-proxy.ns.svc.cluster.local:6651/");
         expectedData.put("PULSAR_PREFIX_webServiceUrl", "https://pul-proxy.ns.svc.cluster.local:8443/");
         expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -1035,7 +1030,6 @@ public class BastionControllerTest {
         expectedData.put("PULSAR_PREFIX_brokerServiceUrl", "pulsar://pul-broker.ns.svc.cluster.local:6650/");
         expectedData.put("PULSAR_PREFIX_webServiceUrl", "http://pul-broker.ns.svc.cluster.local:8080/");
         expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
@@ -97,10 +97,9 @@ public class BrokerControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_MEM: -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError
+                          PULSAR_MEM: -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError
                           PULSAR_PREFIX_allowAutoTopicCreationType: non-partitioned
                           PULSAR_PREFIX_backlogQuotaDefaultRetentionPolicy: producer_exception
                           PULSAR_PREFIX_bookkeeperClientRegionawarePolicyEnabled: "true"
@@ -294,9 +293,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -338,9 +336,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -448,9 +445,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "debug");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -487,9 +483,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -561,9 +556,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -753,9 +747,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -1847,9 +1840,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -1951,9 +1943,8 @@ public class BrokerControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_allowAutoTopicCreationType", "non-partitioned");
         expectedData.put("PULSAR_MEM",
-                "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
+                "-Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler"
                         + ".linkCapacity=1024 -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
@@ -152,10 +152,9 @@ public class FunctionsWorkerControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_MEM: -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError
+                          PULSAR_MEM: -XX:+ExitOnOutOfMemoryError
                                                 """);
 
         Assert.assertEquals(client.getCreatedResources(Service.class).get(0).getResourceYaml(),
@@ -748,8 +747,7 @@ public class FunctionsWorkerControllerTest {
                 client.getCreatedResources(ConfigMap.class).get(1);
 
         Map<String, Object> expectedData = new HashMap<>();
-        expectedData.put("PULSAR_MEM", "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
+        expectedData.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "debug");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -827,8 +825,7 @@ public class FunctionsWorkerControllerTest {
 
 
         Map<String, Object> expectedDataForExtra = new HashMap<>();
-        expectedDataForExtra.put("PULSAR_MEM", "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError");
-        expectedDataForExtra.put("PULSAR_GC", "-XX:+UseG1GC");
+        expectedDataForExtra.put("PULSAR_MEM", "-XX:+ExitOnOutOfMemoryError");
         expectedDataForExtra.put("PULSAR_LOG_LEVEL", "info");
         expectedDataForExtra.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedDataForExtra.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxyControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxyControllerTest.java
@@ -91,10 +91,8 @@ public class ProxyControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_MEM: -Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g
                           PULSAR_PREFIX_brokerServiceURL: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
                           PULSAR_PREFIX_brokerServiceURLTLS: pulsar+ssl://pulsarname-broker.ns.svc.cluster.local:6651/
                           PULSAR_PREFIX_brokerWebServiceURL: http://pulsarname-broker.ns.svc.cluster.local:8080/
@@ -127,10 +125,8 @@ public class ProxyControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_MEM: -Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g
                           PULSAR_PREFIX_brokerServiceUrl: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
                           PULSAR_PREFIX_brokerServiceUrlTls: pulsar+ssl://pulsarname-broker.ns.svc.cluster.local:6651/
                           PULSAR_PREFIX_clusterName: pulsarname
@@ -353,8 +349,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_configurationStoreServers", "pul-zookeeper-ca.ns.svc.cluster.local:2181");
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "debug");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -386,8 +380,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_configurationStoreServers", "pul-zookeeper-ca.ns.svc.cluster.local:2181");
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -418,8 +410,6 @@ public class ProxyControllerTest {
         expectedDataForWs.put("PULSAR_PREFIX_clusterName", "pul");
         expectedDataForWs.put("PULSAR_PREFIX_webServicePort", "8000");
 
-        expectedDataForWs.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedDataForWs.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedDataForWs.put("PULSAR_LOG_LEVEL", "info");
         expectedDataForWs.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedDataForWs.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -505,8 +495,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
         expectedData.put("PULSAR_PREFIX_webServicePort", "8000");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "trace");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -550,8 +538,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_configurationStoreServers", "pul-zookeeper-ca.ns.svc.cluster.local:2181");
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -589,8 +575,6 @@ public class ProxyControllerTest {
         wsExpectedData.put("PULSAR_PREFIX_clusterName", "pul");
         wsExpectedData.put("PULSAR_PREFIX_webServicePort", "8000");
 
-        wsExpectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        wsExpectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         wsExpectedData.put("PULSAR_LOG_LEVEL", "info");
         wsExpectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         wsExpectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -1700,8 +1684,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_configurationStoreServers", "pul-zookeeper-ca.ns.svc.cluster.local:2181");
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");
@@ -1800,8 +1782,6 @@ public class ProxyControllerTest {
         expectedData.put("PULSAR_PREFIX_configurationStoreServers", "pul-zookeeper-ca.ns.svc.cluster.local:2181");
         expectedData.put("PULSAR_PREFIX_clusterName", "pul");
 
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS", "-Dpulsar.log.root.level=info");

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
@@ -97,10 +97,9 @@ public class ZooKeeperControllerTest {
                             name: pulsarname-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info
-                          PULSAR_GC: -XX:+UseG1GC
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_MEM: -Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760
+                          PULSAR_MEM: -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760
                         """);
 
 
@@ -442,8 +441,7 @@ public class ZooKeeperControllerTest {
                 client.getCreatedResource(ConfigMap.class);
 
         Map<String, String> expectedData = new HashMap<>();
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
+        expectedData.put("PULSAR_MEM", "-Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS",
@@ -473,8 +471,7 @@ public class ZooKeeperControllerTest {
                 client.getCreatedResource(ConfigMap.class);
 
         Map<String, String> expectedData = new HashMap<>();
-        expectedData.put("PULSAR_MEM", "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
-        expectedData.put("PULSAR_GC", "-XX:+UseG1GC");
+        expectedData.put("PULSAR_MEM", "-Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760");
         expectedData.put("PULSAR_LOG_LEVEL", "info");
         expectedData.put("PULSAR_LOG_ROOT_LEVEL", "info");
         expectedData.put("PULSAR_EXTRA_OPTS",


### PR DESCRIPTION
Fixes https://github.com/datastax/kaap/issues/115

The JVM is pretty good at determining appropriate default memory settings.

Changes: 
* Do not set PULSAR_MEM memory settings by default
* Do not set default GC since it's better to rely on the default provided by the JDK (or Pulsar's defaults)
