### PR TITLE
Operator configmap: use KAAP as prefix

### DIFF
--- a/helm/kaap/templates/configmap.yaml
+++ b/helm/kaap/templates/configmap.yaml
@@ -28,6 +28,6 @@ data:
   {{ printf "QUARKUS_%s" ($key | replace "-" "." | replace "\"" "." | snakecase | upper | replace "." "_" ) }}: {{ $val | toString | replace "\"" "" | trim | quote }}
 {{- end }}
 {{- range $key, $val := $.Values.operator.config.operator }}
-  {{ printf "PULSAR_OPERATOR_%s" ($key | replace "-" "." | snakecase | upper | replace "." "_" | replace "\"" "_") }}: {{ $val | toString | replace "\"" "" | trim | quote }}
+  {{ printf "KAAP_%s" ($key | replace "-" "." | snakecase | upper | replace "." "_" | replace "\"" "_") }}: {{ $val | toString | replace "\"" "" | trim | quote }}
 {{- end }}
 {{- end }}

--- a/operator/src/main/java/com/datastax/oss/kaap/LeaderElectionConfig.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/LeaderElectionConfig.java
@@ -23,9 +23,9 @@ import javax.enterprise.context.ApplicationScoped;
 @Unremovable
 public class LeaderElectionConfig extends LeaderElectionConfiguration {
 
-    public static final String PULSAR_OPERATOR_LEASE_NAME = "kaap-lease";
+    public static final String LEASE_NAME = "kaap-lease";
 
     public LeaderElectionConfig() {
-        super(PULSAR_OPERATOR_LEASE_NAME);
+        super(LEASE_NAME);
     }
 }

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
@@ -81,7 +81,7 @@ import org.testng.annotations.BeforeMethod;
 @Slf4j
 public abstract class BaseK8sEnvTest {
 
-    public static final Path PULSAR_OPERATOR_CHART_PATH = Paths.get("..", "helm", "kaap");
+    public static final Path OPERATOR_CHART_PATH = Paths.get("..", "helm", "kaap");
 
     public static final String OPERATOR_IMAGE = System.getProperty("kaap.tests.operator.image",
             "datastax/kaap:latest-dev");
@@ -116,7 +116,7 @@ public abstract class BaseK8sEnvTest {
     @SneakyThrows
     private static List<Path> getCRDsManifests() {
         return Files.list(
-                        Paths.get(PULSAR_OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "crds")
+                        Paths.get(OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "crds")
                 ).filter(p -> p.toFile().getName().endsWith(".yml"))
                 .collect(Collectors.toList());
     }
@@ -179,10 +179,10 @@ public abstract class BaseK8sEnvTest {
     private String getRbacManifest() throws IOException {
         List<String> allRbac = new ArrayList<>();
         allRbac.addAll(Files.readAllLines(
-                Paths.get(PULSAR_OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "rbac.yaml")));
+                Paths.get(OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "rbac.yaml")));
         allRbac.add("---");
         allRbac.addAll(Files.readAllLines(
-                Paths.get(PULSAR_OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "serviceaccount.yaml")));
+                Paths.get(OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "serviceaccount.yaml")));
 
         return simulateHelmRendering(allRbac);
     }
@@ -190,7 +190,7 @@ public abstract class BaseK8sEnvTest {
     private String getOperatorDeploymentManifest() throws IOException {
         List<String> manifests = new ArrayList<>();
         manifests.addAll(Files.readAllLines(
-                Paths.get(PULSAR_OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "operator.yaml")));
+                Paths.get(OPERATOR_CHART_PATH.toFile().getAbsolutePath(), "templates", "operator.yaml")));
         manifests.add("---");
         manifests.addAll(Arrays.stream("""
                 apiVersion: v1

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/BaseHelmTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/BaseHelmTest.java
@@ -42,8 +42,8 @@ public class BaseHelmTest extends BasePulsarClusterTest {
             "https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml";
 
     private static final String HELM_RELEASE_PREFIX = "pothr-";
-    public static final String HELM_BIND_PULSAR_OPERATOR = "/helm-kaap";
-    public static final String HELM_BIND_PULSAR_STACK = "/helm-kaap-stack";
+    public static final String HELM_BIND_OPERATOR = "/helm-kaap";
+    public static final String HELM_BIND_STACK = "/helm-kaap-stack";
 
     protected String helmReleaseName;
 
@@ -58,10 +58,10 @@ public class BaseHelmTest extends BasePulsarClusterTest {
                 + namespace + "-r-" + RandomStringUtils.randomAlphabetic(8).toLowerCase();
         cleanupNonNamespaceableResources();
         env.withHelmContainer(helm -> {
-            final Path operatorPath = PULSAR_OPERATOR_CHART_PATH;
+            final Path operatorPath = OPERATOR_CHART_PATH;
             final Path stackPath = Paths.get("..", "helm", "kaap-stack");
-            helm.withFileSystemBind(operatorPath.toFile().getAbsolutePath(), HELM_BIND_PULSAR_OPERATOR);
-            helm.withFileSystemBind(stackPath.toFile().getAbsolutePath(), HELM_BIND_PULSAR_STACK);
+            helm.withFileSystemBind(operatorPath.toFile().getAbsolutePath(), HELM_BIND_OPERATOR);
+            helm.withFileSystemBind(stackPath.toFile().getAbsolutePath(), HELM_BIND_STACK);
             log.info("loaded helm charts from {} and {}", operatorPath, stackPath);
         });
     }
@@ -100,9 +100,9 @@ public class BaseHelmTest extends BasePulsarClusterTest {
 
     private static String getChartPath(Chart chart) {
         if (chart == Chart.OPERATOR) {
-            return HELM_BIND_PULSAR_OPERATOR;
+            return HELM_BIND_OPERATOR;
         } else {
-            return HELM_BIND_PULSAR_STACK;
+            return HELM_BIND_STACK;
         }
     }
 

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/HelmTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/HelmTest.java
@@ -65,7 +65,7 @@ public class HelmTest extends BaseHelmTest {
                     "debug");
             Assert.assertEquals(configMap.getData().get("QUARKUS_OPERATOR_SDK_CONTROLLERS__CONTROLLERS__RETRY_INTERVAL_INITIAL"),
                     "2500");
-            Assert.assertEquals(configMap.getData().get("PULSAR_OPERATOR_RECONCILIATION_RESCHEDULE_SECONDS"),
+            Assert.assertEquals(configMap.getData().get("KAAP_RECONCILIATION_RESCHEDULE_SECONDS"),
                     "3");
 
             final List<Pod> pods = getOperatorPods();
@@ -73,7 +73,7 @@ public class HelmTest extends BaseHelmTest {
             Awaitility.await().untilAsserted(() -> {
                 Assert.assertNotNull(client.leases()
                         .inNamespace(namespace)
-                        .withName(LeaderElectionConfig.PULSAR_OPERATOR_LEASE_NAME)
+                        .withName(LeaderElectionConfig.LEASE_NAME)
                         .get());
             });
 


### PR DESCRIPTION
Fixes #105

Currently the operator-specific settings are not picked if installing with helm. 
The direct effect is that you cannot change the reconciliation period at the moment (which is a very low severity issue)