### PR TITLE
tls global default should be null

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
@@ -50,7 +50,6 @@ public class GlobalSpec extends ValidableSpec<GlobalSpec> implements WithDefault
     public static final String DEFAULT_TLS_SECRET_NAME = "pulsar-tls";
 
     private static final Supplier<TlsConfig> DEFAULT_TLS_CONFIG = () -> TlsConfig.builder()
-            .enabled(false)
             .caPath("/etc/ssl/certs/ca-certificates.crt")
             .defaultSecretName(DEFAULT_TLS_SECRET_NAME)
             .zookeeper(TlsConfig.TlsEntryConfig.builder()


### PR DESCRIPTION
The TLS global default will override resource specific settings if it's set to false.  Therefore, the default should be `null` to allow individual resource defaults and overrides to take effect.

Fixes #136 