### PR TITLE
Improve Bastion certs default secretName

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -32,6 +32,7 @@ jobs:
           if [[ `git status --porcelain` ]]; then
             echo "Found files changed after building, please run ./src/generate-crds-docs.sh and commit the changes"
             git status
+            git diff
             exit 1
           fi
       

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
@@ -535,11 +535,7 @@ public abstract class BaseResourcesFactory<T> {
                 ? null : global.getTls().getSsCa().getSecretName();
         return ObjectUtils.firstNonNull(
                 name,
-                global.getTls().getDefaultSecretName());
-    }
-
-    protected String getTlsSsCaSecretName() {
-        return getTlsSsCaSecretName(global);
+                "%s-ss-ca".formatted(global.getName()));
     }
 
     protected String getTlsSecretNameForAutorecovery() {

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/BaseResourcesFactory.java
@@ -535,7 +535,7 @@ public abstract class BaseResourcesFactory<T> {
                 ? null : global.getTls().getSsCa().getSecretName();
         return ObjectUtils.firstNonNull(
                 name,
-                "%s-ss-ca".formatted(global.getName()));
+                global.getTls().getDefaultSecretName());
     }
 
     protected String getTlsSsCaSecretName() {

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
@@ -128,8 +128,11 @@ public class BastionResourcesFactory extends BaseResourcesFactory<BastionSpec> {
 
         List<VolumeMount> volumeMounts = new ArrayList<>();
         List<Volume> volumes = new ArrayList<>();
-        if (isTlsEnabledOnProxy() || isTlsEnabledOnBroker()) {
-            addTlsVolumes(volumeMounts, volumes, getTlsSsCaSecretName());
+        boolean targetProxy = spec.getTargetProxy() != null && spec.getTargetProxy();
+        boolean targetTlsEnabled = targetProxy ? isTlsEnabledOnProxy() : isTlsEnabledOnBroker();
+        if (targetTlsEnabled) {
+            final String secret = targetProxy ? getTlsSecretNameForProxy() : getTlsSecretNameForBroker();
+            addTlsVolumes(volumeMounts, volumes, secret);
         }
         String mainArg = "";
 

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
@@ -254,8 +254,29 @@ public class BastionControllerTest {
         final Deployment deployment = client.getCreatedResource(Deployment.class).getResource();
         KubeTestUtil.assertTlsVolumesMounted(
                 deployment,
-                "pul-ss-ca"
+                "pulsar-tls"
         );
+    }
+
+    @Test
+    public void testTlsEnabledOnBrokerWithPerComponentCert() throws Exception {
+        String spec = """
+                global:
+                    name: pul
+                    persistence: false
+                    image: apachepulsar/pulsar:global
+                    tls:
+                        enabled: true
+                        broker:
+                            enabled: true
+                            secretName: broker-tls
+                bastion:
+                    targetProxy: false
+                """;
+        MockKubernetesClient client = invokeController(spec);
+
+        final Deployment deployment = client.getCreatedResource(Deployment.class).getResource();
+        KubeTestUtil.assertTlsVolumesMounted(deployment, "broker-tls");
     }
 
     @Test
@@ -294,8 +315,29 @@ public class BastionControllerTest {
         final Deployment deployment = client.getCreatedResource(Deployment.class).getResource();
         KubeTestUtil.assertTlsVolumesMounted(
                 deployment,
-                "pul-ss-ca"
+                "pulsar-tls"
         );
+    }
+
+    @Test
+    public void testTlsEnabledOnProxyWithPerComponentCert() throws Exception {
+        String spec = """
+                global:
+                    name: pul
+                    persistence: false
+                    image: apachepulsar/pulsar:global
+                    tls:
+                        enabled: true
+                        proxy:
+                            enabled: true
+                            secretName: proxy-tls
+                bastion:
+                    targetProxy: true
+                """;
+        MockKubernetesClient client = invokeController(spec);
+
+        final Deployment deployment = client.getCreatedResource(Deployment.class).getResource();
+        KubeTestUtil.assertTlsVolumesMounted(deployment, "proxy-tls");
     }
 
 

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/utils/CertManagerCertificatesProvisionerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/utils/CertManagerCertificatesProvisionerTest.java
@@ -54,7 +54,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pulsar-tls
+                          secretName: pul-ss-ca
                           usages:
                           - server auth
                           - client auth
@@ -99,7 +99,7 @@ public class CertManagerCertificatesProvisionerTest {
                           namespace: ns
                         spec:
                           ca:
-                            secretName: pulsar-tls
+                            secretName: pul-ss-ca
                         """);
 
     }
@@ -142,7 +142,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pulsar-tls
+                          secretName: pul-ss-ca
                           usages:
                           - server auth
                           - client auth
@@ -221,7 +221,7 @@ public class CertManagerCertificatesProvisionerTest {
                           namespace: ns
                         spec:
                           ca:
-                            secretName: pulsar-tls
+                            secretName: pul-ss-ca
                         """);
 
     }
@@ -442,7 +442,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pulsar-tls
+                          secretName: pul-ss-ca
                           usages:
                           - server auth
                           - client auth

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/utils/CertManagerCertificatesProvisionerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/utils/CertManagerCertificatesProvisionerTest.java
@@ -54,7 +54,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pul-ss-ca
+                          secretName: pulsar-tls
                           usages:
                           - server auth
                           - client auth
@@ -99,7 +99,7 @@ public class CertManagerCertificatesProvisionerTest {
                           namespace: ns
                         spec:
                           ca:
-                            secretName: pul-ss-ca
+                            secretName: pulsar-tls
                         """);
 
     }
@@ -142,7 +142,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pul-ss-ca
+                          secretName: pulsar-tls
                           usages:
                           - server auth
                           - client auth
@@ -221,7 +221,7 @@ public class CertManagerCertificatesProvisionerTest {
                           namespace: ns
                         spec:
                           ca:
-                            secretName: pul-ss-ca
+                            secretName: pulsar-tls
                         """);
 
     }
@@ -442,7 +442,7 @@ public class CertManagerCertificatesProvisionerTest {
                           isCA: true
                           issuerRef:
                             name: pul-self-signed-issuer
-                          secretName: pul-ss-ca
+                          secretName: pulsar-tls
                           usages:
                           - server auth
                           - client auth

--- a/src/generate-crds-docs.sh
+++ b/src/generate-crds-docs.sh
@@ -18,7 +18,7 @@
 
 set -e
 echo "Generating CRDs docs"
-mvn package -Pupdate-crds -pl operator
+mvn clean package -Pupdate-crds -pl operator
 docker run -u $(id -u):$(id -g) --rm -v ${PWD}:/workdir ghcr.io/fybrik/crdoc:latest \
   --resources /workdir/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml \
   --template /workdir/src/reference-markdown-template.tmpl \

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
@@ -30,6 +30,9 @@ import com.datastax.oss.kaap.crds.zookeeper.ZooKeeper;
 import com.datastax.oss.kaap.tests.env.ExistingK8sEnv;
 import com.datastax.oss.kaap.tests.env.K3sEnv;
 import com.datastax.oss.kaap.tests.env.K8sEnv;
+import io.fabric8.certmanager.api.model.v1.Certificate;
+import io.fabric8.certmanager.api.model.v1.CertificateRequest;
+import io.fabric8.certmanager.api.model.v1.Issuer;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Node;
@@ -459,6 +462,9 @@ public abstract class BaseK8sEnvTest {
         dumpResources(filePrefix, FunctionsWorker.class);
         dumpResources(filePrefix, Bastion.class);
         dumpResources(filePrefix, Autorecovery.class);
+        dumpResources(filePrefix, CertificateRequest.class);
+        dumpResources(filePrefix, Certificate.class);
+        dumpResources(filePrefix, Issuer.class);
     }
 
     private void dumpResources(String filePrefix, Class<? extends HasMetadata> clazz) {

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
@@ -468,11 +468,15 @@ public abstract class BaseK8sEnvTest {
     }
 
     private void dumpResources(String filePrefix, Class<? extends HasMetadata> clazz) {
-        client.resources(clazz)
-                .inNamespace(namespace)
-                .list()
-                .getItems()
-                .forEach(resource -> dumpResource(filePrefix, resource));
+        try {
+            client.resources(clazz)
+                    .inNamespace(namespace)
+                    .list()
+                    .getItems()
+                    .forEach(resource -> dumpResource(filePrefix, resource));
+        } catch (Throwable t) {
+            log.error("failed to dump resources of type {}", clazz, t);
+        }
     }
 
     protected void dumpResource(String filePrefix, HasMetadata resource) {

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
@@ -462,12 +462,26 @@ public abstract class BaseK8sEnvTest {
         dumpResources(filePrefix, FunctionsWorker.class);
         dumpResources(filePrefix, Bastion.class);
         dumpResources(filePrefix, Autorecovery.class);
-        dumpResources(filePrefix, CertificateRequest.class);
-        dumpResources(filePrefix, Certificate.class);
-        dumpResources(filePrefix, Issuer.class);
+        dumpResourcesAllNamespaces(filePrefix, CertificateRequest.class);
+        dumpResourcesAllNamespaces(filePrefix, Certificate.class);
+        dumpResourcesAllNamespaces(filePrefix, Issuer.class);
+    }
+
+    private void dumpResourcesAllNamespaces(String filePrefix, Class<? extends HasMetadata> clazz) {
+        try {
+            client.namespaces().list()
+                    .getItems()
+                    .forEach(ns -> dumpResources(filePrefix, clazz, ns.getMetadata().getName()));
+        } catch (Throwable t) {
+            log.error("failed to list namespaces for getting resource of class {}: {}", clazz, t.getMessage());
+        }
     }
 
     private void dumpResources(String filePrefix, Class<? extends HasMetadata> clazz) {
+        dumpResources(filePrefix, clazz, namespace);
+    }
+
+    private void dumpResources(String filePrefix, Class<? extends HasMetadata> clazz, String namespace) {
         try {
             client.resources(clazz)
                     .inNamespace(namespace)
@@ -475,7 +489,7 @@ public abstract class BaseK8sEnvTest {
                     .getItems()
                     .forEach(resource -> dumpResource(filePrefix, resource));
         } catch (Throwable t) {
-            log.error("failed to dump resources of type {}", clazz, t);
+            log.error("failed to dump resources of type {}: {}", clazz, t.getMessage());
         }
     }
 


### PR DESCRIPTION
The bastion should load the right certs based on the target (proxy or broker). It has to deal both with perCompoenent certs or the global one. Currently it loads the ca-cert but it's not necessary 