### PR TITLE
feature: new field to set pulsar cluster name

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -55916,7 +55916,7 @@ Update strategy for the StatefulSet.
         <td><b>name</b></td>
         <td>string</td>
         <td>
-          Pulsar cluster name.<br/>
+          Name of the Pulsar cluster spec.  This is used as a prefix for managed Kubernetes resources.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -55932,6 +55932,13 @@ Update strategy for the StatefulSet.
         <td>
           Authentication and authorization configuration.
 <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>clusterName</b></td>
+        <td>string</td>
+        <td>
+          Corresponds to the 'clusterName' field in the broker.conf.  Defaults to the value of the 'name' field<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/helm/kaap/crds/autorecoveries.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/autorecoveries.kaap.oss.datastax.com-v1.yml
@@ -1254,6 +1254,103 @@ spec:
                 type: object
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -1555,53 +1652,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -1650,16 +1704,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -1713,9 +1757,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -1726,9 +1767,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -1763,39 +1801,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/bastions.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bastions.kaap.oss.datastax.com-v1.yml
@@ -1258,6 +1258,103 @@ spec:
                 type: object
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -1559,53 +1656,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -1654,16 +1708,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -1717,9 +1761,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -1730,9 +1771,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -1767,39 +1805,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
@@ -21,6 +21,103 @@ spec:
             properties:
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -322,53 +419,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -417,16 +471,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -480,9 +524,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -493,9 +534,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -530,39 +568,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/brokers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/brokers.kaap.oss.datastax.com-v1.yml
@@ -21,6 +21,103 @@ spec:
             properties:
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -322,53 +419,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -417,16 +471,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -480,9 +524,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -493,9 +534,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -530,39 +568,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/functionsworkers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/functionsworkers.kaap.oss.datastax.com-v1.yml
@@ -23,6 +23,103 @@ spec:
             properties:
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -324,53 +421,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -419,16 +473,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -482,9 +526,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -495,9 +536,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -532,39 +570,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/proxies.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/proxies.kaap.oss.datastax.com-v1.yml
@@ -21,6 +21,103 @@ spec:
             properties:
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -322,53 +419,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -417,16 +471,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -480,9 +524,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -493,9 +534,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -530,39 +568,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
@@ -21,6 +21,103 @@ spec:
             properties:
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -322,53 +419,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -417,16 +471,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -480,9 +524,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -493,9 +534,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -530,39 +568,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/helm/kaap/crds/zookeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/zookeepers.kaap.oss.datastax.com-v1.yml
@@ -2106,6 +2106,103 @@ spec:
                 type: object
               global:
                 properties:
+                  components:
+                    description: Pulsar cluster components names.
+                    properties:
+                      brokerBaseName:
+                        description: Broker base name. Default value is 'broker'.
+                        type: string
+                      zookeeperBaseName:
+                        description: Zookeeper base name. Default value is 'zookeeper'.
+                        type: string
+                      functionsWorkerBaseName:
+                        description: Functions Worker base name. Default value is
+                          'function'.
+                        type: string
+                      autorecoveryBaseName:
+                        description: Autorecovery base name. Default value is 'autorecovery'.
+                        type: string
+                      bookkeeperBaseName:
+                        description: BookKeeper base name. Default value is 'bookkeeper'.
+                        type: string
+                      bastionBaseName:
+                        description: Bastion base name. Default value is 'bastion'.
+                        type: string
+                      proxyBaseName:
+                        description: Proxy base name. Default value is 'proxy'.
+                        type: string
+                    type: object
+                  dnsConfig:
+                    description: DNS config for each pod.
+                    properties:
+                      nameservers:
+                        items:
+                          type: string
+                        type: array
+                      searches:
+                        items:
+                          type: string
+                        type: array
+                      options:
+                        items:
+                          properties:
+                            value:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  dnsName:
+                    description: Public dns name for the cluster's load balancer.
+                    type: string
+                  kubernetesClusterDomain:
+                    description: |
+                      The domain name for your kubernetes cluster.
+                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
+                      It's used to fully qualify service names when configuring Pulsar.
+                      The default value is 'cluster.local'.
+                    type: string
+                  priorityClassName:
+                    description: Priority class name to attach to each pod.
+                    type: string
+                  name:
+                    description: Name of the Pulsar cluster spec.  This is used as
+                      a prefix for managed Kubernetes resources.
+                    type: string
+                  storage:
+                    description: Storage configuration.
+                    properties:
+                      storageClass:
+                        description: Indicates if a StorageClass is used. The operator
+                          will create the StorageClass if needed.
+                        properties:
+                          extraParams:
+                            additionalProperties:
+                              type: string
+                            description: Adds extra parameters for the StorageClass.
+                            type: object
+                          provisioner:
+                            description: Indicates the provisioner property for the
+                              StorageClass.
+                            type: string
+                          type:
+                            description: Indicates the 'type' parameter for the StorageClass.
+                            type: string
+                          fsType:
+                            description: Indicates the 'fsType' parameter for the
+                              StorageClass.
+                            type: string
+                          reclaimPolicy:
+                            description: Indicates the reclaimPolicy property for
+                              the StorageClass.
+                            type: string
+                        type: object
+                      existingStorageClassName:
+                        description: Indicates if an already existing storage class
+                          should be used.
+                        type: string
+                    type: object
                   tls:
                     description: TLS configuration for the cluster.
                     properties:
@@ -2407,53 +2504,10 @@ spec:
                             type: boolean
                         type: object
                     type: object
-                  components:
-                    description: Pulsar cluster components names.
-                    properties:
-                      brokerBaseName:
-                        description: Broker base name. Default value is 'broker'.
-                        type: string
-                      zookeeperBaseName:
-                        description: Zookeeper base name. Default value is 'zookeeper'.
-                        type: string
-                      functionsWorkerBaseName:
-                        description: Functions Worker base name. Default value is
-                          'function'.
-                        type: string
-                      autorecoveryBaseName:
-                        description: Autorecovery base name. Default value is 'autorecovery'.
-                        type: string
-                      bookkeeperBaseName:
-                        description: BookKeeper base name. Default value is 'bookkeeper'.
-                        type: string
-                      bastionBaseName:
-                        description: Bastion base name. Default value is 'bastion'.
-                        type: string
-                      proxyBaseName:
-                        description: Proxy base name. Default value is 'proxy'.
-                        type: string
-                    type: object
-                  dnsConfig:
-                    description: DNS config for each pod.
-                    properties:
-                      nameservers:
-                        items:
-                          type: string
-                        type: array
-                      searches:
-                        items:
-                          type: string
-                        type: array
-                      options:
-                        items:
-                          properties:
-                            value:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                    type: object
+                  clusterName:
+                    description: Corresponds to the 'clusterName' field in the broker.conf.  Defaults
+                      to the value of the 'name' field
+                    type: string
                   restartOnConfigMapChange:
                     description: |
                       By default, Kubernetes will not restart pods when only their configmap is changed. This setting will restart pods when their configmap is changed using an annotation that calculates the checksum of the configmap.
@@ -2502,16 +2556,6 @@ spec:
                     description: |
                       If persistence is enabled, components that has state will be deployed with PersistentVolumeClaims, otherwise, for test purposes, they will be deployed with emptyDir
                     type: boolean
-                  dnsName:
-                    description: Public dns name for the cluster's load balancer.
-                    type: string
-                  kubernetesClusterDomain:
-                    description: |
-                      The domain name for your kubernetes cluster.
-                      This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1 .
-                      It's used to fully qualify service names when configuring Pulsar.
-                      The default value is 'cluster.local'.
-                    type: string
                   racks:
                     additionalProperties:
                       properties:
@@ -2565,9 +2609,6 @@ spec:
                       type: object
                     description: Racks configuration.
                     type: object
-                  priorityClassName:
-                    description: Priority class name to attach to each pod.
-                    type: string
                   resourceSets:
                     additionalProperties:
                       properties:
@@ -2578,9 +2619,6 @@ spec:
                       type: object
                     description: Resource sets.
                     type: object
-                  name:
-                    description: Pulsar cluster name.
-                    type: string
                   nodeSelectors:
                     additionalProperties:
                       type: string
@@ -2615,39 +2653,6 @@ spec:
                               the StorageClass.
                             type: boolean
                         type: object
-                    type: object
-                  storage:
-                    description: Storage configuration.
-                    properties:
-                      storageClass:
-                        description: Indicates if a StorageClass is used. The operator
-                          will create the StorageClass if needed.
-                        properties:
-                          extraParams:
-                            additionalProperties:
-                              type: string
-                            description: Adds extra parameters for the StorageClass.
-                            type: object
-                          provisioner:
-                            description: Indicates the provisioner property for the
-                              StorageClass.
-                            type: string
-                          type:
-                            description: Indicates the 'type' parameter for the StorageClass.
-                            type: string
-                          fsType:
-                            description: Indicates the 'fsType' parameter for the
-                              StorageClass.
-                            type: string
-                          reclaimPolicy:
-                            description: Indicates the reclaimPolicy property for
-                              the StorageClass.
-                            type: string
-                        type: object
-                      existingStorageClassName:
-                        description: Indicates if an already existing storage class
-                          should be used.
-                        type: string
                     type: object
                   zookeeperPlainSslStorePassword:
                     description: "Use plain password in zookeeper server and client\

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGenerator.java
@@ -91,6 +91,7 @@ public class PulsarClusterResourceGenerator {
 
         final GlobalSpec global = GlobalSpec.builder()
                 .name(inputSpecs.getClusterName())
+                .clusterName(inputSpecs.getClusterName())
                 .components(getComponentsConfig())
                 .dnsConfig(getPodDNSConfig())
                 .dnsName(getDnsName())

--- a/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
+++ b/migration-tool/src/test/java/com/datastax/oss/kaap/migrationtool/PulsarClusterResourceGeneratorTest.java
@@ -115,6 +115,7 @@ public class PulsarClusterResourceGeneratorTest {
                         spec:
                           global:
                             name: pulsar-cluster
+                            clusterName: pulsar-cluster
                             components:
                               zookeeperBaseName: zookeeper
                               bookkeeperBaseName: bookkeeper

--- a/operator/src/main/java/com/datastax/oss/kaap/autoscaler/BookKeeperSetAutoscaler.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/autoscaler/BookKeeperSetAutoscaler.java
@@ -95,10 +95,10 @@ public class BookKeeperSetAutoscaler implements Runnable {
         final BookKeeperAutoscalerSpec autoscalerSpec = desiredBookKeeperSetSpec.getAutoscaler();
         Objects.requireNonNull(autoscalerSpec);
 
-        final String clusterName = clusterSpec.getGlobal().getName();
+        final String clusterSpecName = clusterSpec.getGlobal().getName();
         final String bkBaseName = clusterSpec.getGlobal()
                 .getComponents().getBookkeeperBaseName();
-        final String bkName = "%s-%s".formatted(clusterName, bkBaseName);
+        final String bkName = "%s-%s".formatted(clusterSpecName, bkBaseName);
         @Valid BookKeeperAutoscalerSpec bkScalerSpec = clusterSpec.getBookkeeper().getAutoscaler();
         final double diskUsageHwm = bkScalerSpec.getDiskUsageToleranceHwm();
         final double diskUsageLwm = bkScalerSpec.getDiskUsageToleranceLwm();
@@ -132,13 +132,13 @@ public class BookKeeperSetAutoscaler implements Runnable {
 
         final int currentExpectedReplicas = currentBkSetSpec.getReplicas();
 
-        final String statefulsetName = BookKeeperResourcesFactory.getResourceName(clusterName,
+        final String statefulsetName = BookKeeperResourcesFactory.getResourceName(clusterSpecName,
                 currentGlobalSpec.getComponents().getBookkeeperBaseName(), bookkeeperSetName,
                 currentBkSetSpec.getOverrideResourceName());
         final String componentLabelValue = BookKeeperResourcesFactory.getComponentBaseName(currentGlobalSpec);
 
         final Map<String, String> podSelector = new TreeMap<>(Map.of(
-                CRDConstants.LABEL_CLUSTER, clusterName,
+                CRDConstants.LABEL_CLUSTER, clusterSpecName,
                 CRDConstants.LABEL_COMPONENT, componentLabelValue,
                 CRDConstants.LABEL_RESOURCESET, bookkeeperSetName));
 
@@ -150,7 +150,7 @@ public class BookKeeperSetAutoscaler implements Runnable {
                 autoscalerSpec.getStabilizationWindowMs(),
                 namespace, statefulsetName, podSelector, currentExpectedReplicas)) {
             log.infof("BookKeeper cluster %s %s is not ready to scale, expect replicas: %d",
-                    clusterName, bkName, currentExpectedReplicas);
+                    clusterSpecName, bkName, currentExpectedReplicas);
             return;
         }
 

--- a/operator/src/main/java/com/datastax/oss/kaap/autoscaler/BrokerSetAutoscaler.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/autoscaler/BrokerSetAutoscaler.java
@@ -76,7 +76,7 @@ public class BrokerSetAutoscaler implements Runnable {
         final BrokerAutoscalerSpec autoscalerSpec = desiredBrokerSetSpec.getAutoscaler();
         Objects.requireNonNull(autoscalerSpec);
 
-        final String clusterName = clusterSpec.getGlobal().getName();
+        final String clusterSpecName = clusterSpec.getGlobal().getName();
         final String brokerCustomResourceName = PulsarClusterController.computeCustomResourceName(clusterSpec,
                 PulsarClusterController.CUSTOM_RESOURCE_BROKER);
         final Broker brokerCr = client.resources(Broker.class)
@@ -96,13 +96,13 @@ public class BrokerSetAutoscaler implements Runnable {
         final int currentExpectedReplicas = currentBrokerSetSpec.getReplicas().intValue();
 
 
-        final String statefulsetName = BrokerResourcesFactory.getResourceName(clusterName,
+        final String statefulsetName = BrokerResourcesFactory.getResourceName(clusterSpecName,
                 currentGlobalSpec.getComponents().getBrokerBaseName(), brokerSetName,
                 currentBrokerSetSpec.getOverrideResourceName());
         final String componentLabelValue = BrokerResourcesFactory.getComponentBaseName(currentGlobalSpec);
 
         final Map<String, String> podSelector = new TreeMap<>(Map.of(
-                CRDConstants.LABEL_CLUSTER, clusterName,
+                CRDConstants.LABEL_CLUSTER, clusterSpecName,
                 CRDConstants.LABEL_COMPONENT, componentLabelValue,
                 CRDConstants.LABEL_RESOURCESET, brokerSetName));
 

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
@@ -184,7 +184,7 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
         final String zkServers = getZkServers();
         data.put("zookeeperServers", zkServers);
         data.put("configurationStoreServers", zkServers);
-        data.put("clusterName", global.getName());
+        data.put("clusterName", global.getClusterName());
 
         if (isAuthTokenEnabled()) {
             data.put("authParams", "file:///pulsar/token-superuser-stripped.jwt");
@@ -225,7 +225,7 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
         }
         if (spec.getFunctionsWorkerEnabled()) {
             data.put("functionsWorkerEnabled", "true");
-            data.put("pulsarFunctionsCluster", global.getName());
+            data.put("pulsarFunctionsCluster", global.getClusterName());
 
             // Since function worker connects on localhost, we can always non-TLS ports
             // when running with the broker
@@ -465,14 +465,13 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
             mainArgs += generateCertConverterScript() + " && ";
         }
 
-        final String clusterName = global.getName();
         final String zkServers = getZkServers();
 
         mainArgs += """
                 bin/pulsar initialize-transaction-coordinator-metadata --cluster %s \\
                     --configuration-store %s \\
                     --initial-num-transaction-coordinators %d
-                """.formatted(clusterName, zkServers, transactions.getPartitions());
+                """.formatted(global.getClusterName(), zkServers, transactions.getPartitions());
 
         final Container container = new ContainerBuilder()
                 .withName(resourceName)

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -225,7 +225,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
         data.put("configurationStoreServers", zkServers);
         data.put("zookeeperServers", zkServers);
         data.put("zooKeeperSessionTimeoutMillis", "30000");
-        data.put("pulsarFunctionsCluster", global.getName());
+        data.put("pulsarFunctionsCluster", global.getClusterName());
         data.put("workerId", resourceName);
         data.put(ENV_WORKER_HOSTNAME, resourceName);
         data.put("workerPort", "6750");

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
@@ -221,7 +221,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
         data.put("brokerWebServiceURLTLS", getBrokerWebServiceUrlTls());
         data.put("zookeeperServers", zkServers);
         data.put("configurationStoreServers", zkServers);
-        data.put("clusterName", global.getName());
+        data.put("clusterName", global.getClusterName());
         boolean isStandaloneFunctionsWorker = spec.getStandaloneFunctionsWorker() != null
                 && spec.getStandaloneFunctionsWorker();
         final String functionsWorkerServiceUrl = getFunctionsWorkerServiceUrl();
@@ -315,7 +315,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
         data.put("serviceUrlTls", getBrokerWebServiceUrlTls());
         data.put("zookeeperServers", zkServers);
         data.put("configurationStoreServers", zkServers);
-        data.put("clusterName", global.getName());
+        data.put("clusterName", global.getClusterName());
 
         data.putAll(DEFAULT_CONFIG_MAP);
         if (isAuthTokenEnabled()) {

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -403,14 +403,12 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
             mainArgs += generateCertConverterScript() + " && ";
         }
 
-        final String clusterName = global.getName();
-
         final String zkServers = getZkServers();
         final boolean tlsEnabledOnBroker = isTlsEnabledOnBroker();
 
         mainArgs +=
                 "bin/pulsar initialize-cluster-metadata --cluster %s --zookeeper %s --configuration-store %s"
-                        .formatted(clusterName, zkServers, zkServers);
+                        .formatted(global.getClusterName(), zkServers, zkServers);
 
         mainArgs += " --web-service-url %s --broker-service-url %s"
                 .formatted(getBrokerWebServiceUrlPlain(), getBrokerServiceUrlPlain());

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
@@ -40,6 +40,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor
@@ -155,8 +156,10 @@ public class GlobalSpec extends ValidableSpec<GlobalSpec> implements WithDefault
 
     @NotNull
     @Required
-    @JsonPropertyDescription("Pulsar cluster name.")
+    @JsonPropertyDescription("Name of the Pulsar cluster spec.  This is used as a prefix for managed Kubernetes resources.")
     private String name;
+    @JsonPropertyDescription("Corresponds to the 'clusterName' field in the broker.conf.  Defaults to the value of the 'name' field")
+    private String clusterName;
     @JsonPropertyDescription("Pulsar cluster components names.")
     private Components components;
     @JsonPropertyDescription("DNS config for each pod.")
@@ -212,6 +215,7 @@ public class GlobalSpec extends ValidableSpec<GlobalSpec> implements WithDefault
 
     @Override
     public void applyDefaults(GlobalSpec globalSpec) {
+        clusterName = StringUtils.firstNonBlank(clusterName, name);
         applyComponentsDefaults();
 
         if (kubernetesClusterDomain == null) {

--- a/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BookKeeperAutoscalerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BookKeeperAutoscalerTest.java
@@ -108,7 +108,7 @@ public class BookKeeperAutoscalerTest {
                     .bookkeeper(pulsarClusterSpec.getBookkeeper())
                     .build());
 
-            final String clusterName = pulsarClusterSpec.getGlobal().getName();
+            final String clusterSpecName = pulsarClusterSpec.getGlobal().getName();
 
             server = new KubernetesServer(false);
             server.before();
@@ -136,7 +136,7 @@ public class BookKeeperAutoscalerTest {
 
             server.expect()
                     .get()
-                    .withPath("/apis/apps/v1/namespaces/ns/statefulsets/%s-bookkeeper".formatted(clusterName))
+                    .withPath("/apis/apps/v1/namespaces/ns/statefulsets/%s-bookkeeper".formatted(clusterSpecName))
                     .andReturn(HttpURLConnection.HTTP_OK, sts)
                     .once();
 
@@ -144,7 +144,7 @@ public class BookKeeperAutoscalerTest {
                     .get()
                     .withPath(
                             "/apis/kaap.oss.datastax.com/v1alpha1/namespaces/ns/bookkeepers/%s-bookkeeper".formatted(
-                                    clusterName))
+                                    clusterSpecName))
                     .andReturn(HttpURLConnection.HTTP_OK, bkCr)
                     .times(2);
 
@@ -153,7 +153,7 @@ public class BookKeeperAutoscalerTest {
             List<PodMetrics> podsMetrics = new ArrayList<>();
 
             for (int i = 0; i < replicas; i++) {
-                final String podName = "%s-bookkeeper-%d".formatted(clusterName, i);
+                final String podName = "%s-bookkeeper-%d".formatted(clusterSpecName, i);
                 final Pod pod = new PodBuilder()
                         .withNewMetadata()
                         .withName(podName)
@@ -200,7 +200,7 @@ public class BookKeeperAutoscalerTest {
                     .get()
                     .withPath("/api/v1/namespaces/ns/pods?labelSelector=%s".formatted(
                                     URLEncoder.encode(
-                                            "cluster=%s,component=bookkeeper,resource-set=bookkeeper".formatted(clusterName),
+                                            "cluster=%s,component=bookkeeper,resource-set=bookkeeper".formatted(clusterSpecName),
                                             StandardCharsets.UTF_8)
                             )
                     )
@@ -215,7 +215,7 @@ public class BookKeeperAutoscalerTest {
                     .get()
                     .withPath("/apis/metrics.k8s.io/v1beta1/namespaces/ns/pods?labelSelector=%s".formatted(
                                     URLEncoder.encode(
-                                            "cluster=%s,component=bookkeeper,resource-set=bookkeeper".formatted(clusterName),
+                                            "cluster=%s,component=bookkeeper,resource-set=bookkeeper".formatted(clusterSpecName),
                                             StandardCharsets.UTF_8)
                             )
                     )
@@ -226,7 +226,7 @@ public class BookKeeperAutoscalerTest {
                     .patch()
                     .withPath(
                             "/apis/kaap.oss.datastax.com/v1alpha1/namespaces/ns/bookkeepers/%s-bookkeeper".formatted(
-                                    clusterName))
+                                    clusterSpecName))
                     .andReply(HttpURLConnection.HTTP_OK, new BodyProvider<Object>() {
                         @Override
                         @SneakyThrows

--- a/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BrokerAutoscalerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BrokerAutoscalerTest.java
@@ -94,7 +94,7 @@ public class BrokerAutoscalerTest {
                     .broker(pulsarClusterSpec.getBroker())
                     .build());
 
-            final String clusterName = pulsarClusterSpec.getGlobal().getName();
+            final String clusterSpecName = pulsarClusterSpec.getGlobal().getName();
 
             server = new KubernetesServer(false);
             server.before();
@@ -122,14 +122,14 @@ public class BrokerAutoscalerTest {
 
             server.expect()
                     .get()
-                    .withPath("/apis/apps/v1/namespaces/ns/statefulsets/%s-broker".formatted(clusterName))
+                    .withPath("/apis/apps/v1/namespaces/ns/statefulsets/%s-broker".formatted(clusterSpecName))
                     .andReturn(HttpURLConnection.HTTP_OK, sts)
                     .once();
 
             server.expect()
                     .get()
                     .withPath("/apis/kaap.oss.datastax.com/v1alpha1/namespaces/ns/brokers/%s-broker".formatted(
-                            clusterName))
+                            clusterSpecName))
                     .andReturn(HttpURLConnection.HTTP_OK, brokerCr)
                     .times(2);
 
@@ -138,7 +138,7 @@ public class BrokerAutoscalerTest {
             List<PodMetrics> podsMetrics = new ArrayList<>();
 
             for (int i = 0; i < replicas; i++) {
-                final String podName = "%s-broker-%d".formatted(clusterName, i);
+                final String podName = "%s-broker-%d".formatted(clusterSpecName, i);
                 final Pod pod = new PodBuilder()
                         .withNewMetadata()
                         .withName(podName)
@@ -184,7 +184,7 @@ public class BrokerAutoscalerTest {
                     .get()
                     .withPath("/api/v1/namespaces/ns/pods?labelSelector=%s".formatted(
                                     URLEncoder.encode("cluster=%s,component=broker,resource-set=broker"
-                                                    .formatted(clusterName),
+                                                    .formatted(clusterSpecName),
                                             StandardCharsets.UTF_8)
                             )
                     )
@@ -198,7 +198,7 @@ public class BrokerAutoscalerTest {
             server.expect()
                     .get()
                     .withPath("/apis/metrics.k8s.io/v1beta1/namespaces/ns/pods?labelSelector=%s".formatted(
-                                    URLEncoder.encode("cluster=%s,component=broker,resource-set=broker".formatted(clusterName),
+                                    URLEncoder.encode("cluster=%s,component=broker,resource-set=broker".formatted(clusterSpecName),
                                             StandardCharsets.UTF_8)
                             )
                     )
@@ -208,7 +208,7 @@ public class BrokerAutoscalerTest {
             server.expect()
                     .patch()
                     .withPath("/apis/kaap.oss.datastax.com/v1alpha1/namespaces/ns/brokers/%s-broker".formatted(
-                            clusterName))
+                            clusterSpecName))
                     .andReply(HttpURLConnection.HTTP_OK, new BodyProvider<Object>() {
                         @Override
                         @SneakyThrows

--- a/operator/src/test/java/com/datastax/oss/kaap/autoscaler/broker/LoadReportResourceUsageSourceTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/autoscaler/broker/LoadReportResourceUsageSourceTest.java
@@ -64,7 +64,7 @@ public class LoadReportResourceUsageSourceTest {
                     .broker(pulsarClusterSpec.getBroker())
                     .build());
 
-            final String clusterName = pulsarClusterSpec.getGlobal().getName();
+            final String clusterSpecName = pulsarClusterSpec.getGlobal().getName();
 
             server = new KubernetesServer(false);
             server.before();
@@ -84,7 +84,7 @@ public class LoadReportResourceUsageSourceTest {
             final Integer replicas = pulsarClusterSpec.getBroker().getReplicas();
 
             for (int i = 0; i < replicas; i++) {
-                final String podName = "%s-broker-%d".formatted(clusterName, i);
+                final String podName = "%s-broker-%d".formatted(clusterSpecName, i);
                 final Pod pod = new PodBuilder()
                         .withNewMetadata()
                         .withName(podName)
@@ -102,7 +102,7 @@ public class LoadReportResourceUsageSourceTest {
                     .get()
                     .withPath("/api/v1/namespaces/ns/pods?labelSelector=%s".formatted(
                                     URLEncoder.encode("app=pulsar"
-                                                    .formatted(clusterName),
+                                                    .formatted(clusterSpecName),
                                             StandardCharsets.UTF_8)
                             )
                     )

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/PulsarClusterControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/PulsarClusterControllerTest.java
@@ -51,7 +51,8 @@ public class PulsarClusterControllerTest {
 
     public static final String GLOBAL_SPEC_YAML_PART = """
             global:
-                name: pulsarname
+                name: pulsar-spec-1
+                clusterName: public-ap-southeast-2
                 components:
                   zookeeperBaseName: zookeeper
                   bookkeeperBaseName: bookkeeper
@@ -121,7 +122,8 @@ public class PulsarClusterControllerTest {
     public void testInstallCluster() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
+                    clusterName: public-ap-southeast-2
                     image: apachepulsar/pulsar:2.10.2
                 """;
         // first installation, install zk from scratch
@@ -291,7 +293,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: FunctionsWorker
                 metadata:
-                  name: pulsarname-functionsworker
+                  name: pulsar-spec-1-functionsworker
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -348,7 +350,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: Bastion
                 metadata:
-                  name: pulsarname-bastion
+                  name: pulsar-spec-1-bastion
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -379,7 +381,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: Autorecovery
                 metadata:
-                  name: pulsarname-autorecovery
+                  name: pulsar-spec-1-autorecovery
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -409,7 +411,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: Proxy
                 metadata:
-                  name: pulsarname-proxy
+                  name: pulsar-spec-1-proxy
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -472,7 +474,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: Broker
                 metadata:
-                  name: pulsarname-broker
+                  name: pulsar-spec-1-broker
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -538,7 +540,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: BookKeeper
                 metadata:
-                  name: pulsarname-bookkeeper
+                  name: pulsar-spec-1-bookkeeper
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -609,7 +611,7 @@ public class PulsarClusterControllerTest {
                 apiVersion: kaap.oss.datastax.com/v1alpha1
                 kind: ZooKeeper
                 metadata:
-                  name: pulsarname-zookeeper
+                  name: pulsar-spec-1-zookeeper
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
@@ -719,7 +721,7 @@ public class PulsarClusterControllerTest {
     public void testAuthTokenProvisioner() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -735,7 +737,7 @@ public class PulsarClusterControllerTest {
     public void testResourceSets() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -762,7 +764,7 @@ public class PulsarClusterControllerTest {
     public void testBookKeeperResourceSetsNotDefined() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -786,7 +788,7 @@ public class PulsarClusterControllerTest {
     public void testBrokerResourceSetsNotDefined() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -810,7 +812,7 @@ public class PulsarClusterControllerTest {
     public void testProxyResourceSetsNotDefined() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -835,7 +837,7 @@ public class PulsarClusterControllerTest {
     public void testRacksOk() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -860,7 +862,7 @@ public class PulsarClusterControllerTest {
     public void testRacks() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                     auth:
                         enabled: true
@@ -887,7 +889,8 @@ public class PulsarClusterControllerTest {
     public void testAdjustBookKeeperReplicas() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
+                    clusterName: public-ap-southeast-2
                     image: apachepulsar/pulsar:2.10.2
                 bookkeeper:
                     replicas: 1
@@ -960,7 +963,8 @@ public class PulsarClusterControllerTest {
     public void testAdjustBrokerReplicas() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
+                    clusterName: public-ap-southeast-2
                     image: apachepulsar/pulsar:2.10.2
                 broker:
                     replicas: 1

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryControllerTest.java
@@ -48,13 +48,13 @@ import org.testng.annotations.Test;
 public class AutorecoveryControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -69,16 +69,16 @@ public class AutorecoveryControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: autorecovery
-                          name: pulsarname-autorecovery
+                          name: pulsar-spec-1-autorecovery
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Autorecovery
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           BOOKIE_GC: -XX:+UseG1GC
                           BOOKIE_MEM: -Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError
@@ -87,7 +87,7 @@ public class AutorecoveryControllerTest {
                           PULSAR_LOG_ROOT_LEVEL: info
                           PULSAR_PREFIX_ensemblePlacementPolicy: org.apache.bookkeeper.client.RegionAwareEnsemblePlacementPolicy 
                           PULSAR_PREFIX_reppDnsResolverClass: org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping
-                          PULSAR_PREFIX_zkServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_zkServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                         """);
 
         final String depl = client
@@ -99,22 +99,22 @@ public class AutorecoveryControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: autorecovery
-                  name: pulsarname-autorecovery
+                  name: pulsar-spec-1-autorecovery
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Autorecovery
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   replicas: 1
                   selector:
                     matchLabels:
                       app: pulsar
-                      cluster: pulsarname
+                      cluster: pulsar-spec-1
                       component: autorecovery
                   template:
                     metadata:
@@ -123,7 +123,7 @@ public class AutorecoveryControllerTest {
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: autorecovery
                     spec:
                       affinity:
@@ -132,7 +132,7 @@ public class AutorecoveryControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: autorecovery
                             topologyKey: kubernetes.io/hostname
                       containers:
@@ -143,10 +143,10 @@ public class AutorecoveryControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-autorecovery
+                            name: pulsar-spec-1-autorecovery
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
-                        name: pulsarname-autorecovery
+                        name: pulsar-spec-1-autorecovery
                         ports:
                         - containerPort: 8000
                           name: http
@@ -273,7 +273,7 @@ public class AutorecoveryControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -295,7 +295,7 @@ public class AutorecoveryControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bastion/BastionControllerTest.java
@@ -51,13 +51,13 @@ import org.testng.annotations.Test;
 public class BastionControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -73,23 +73,23 @@ public class BastionControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: bastion
-                          name: pulsarname-bastion
+                          name: pulsar-spec-1-bastion
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Bastion
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
                           PULSAR_MEM: -XX:+ExitOnOutOfMemoryError
-                          PULSAR_PREFIX_brokerServiceUrl: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
-                          PULSAR_PREFIX_webServiceUrl: http://pulsarname-broker.ns.svc.cluster.local:8080/
+                          PULSAR_PREFIX_brokerServiceUrl: pulsar://pulsar-spec-1-broker.ns.svc.cluster.local:6650/
+                          PULSAR_PREFIX_webServiceUrl: http://pulsar-spec-1-broker.ns.svc.cluster.local:8080/
                         """);
 
         final String depl = client
@@ -101,28 +101,28 @@ public class BastionControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: bastion
-                  name: pulsarname-bastion
+                  name: pulsar-spec-1-bastion
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Bastion
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   replicas: 1
                   selector:
                     matchLabels:
                       app: pulsar
-                      cluster: pulsarname
+                      cluster: pulsar-spec-1
                       component: bastion
                   template:
                     metadata:
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: bastion
                     spec:
                       affinity:
@@ -131,7 +131,7 @@ public class BastionControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: bastion
                             topologyKey: kubernetes.io/hostname
                       containers:
@@ -142,10 +142,10 @@ public class BastionControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-bastion
+                            name: pulsar-spec-1-bastion
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
-                        name: pulsarname-bastion
+                        name: pulsar-spec-1-bastion
                         resources:
                           requests:
                             cpu: 0.25
@@ -323,7 +323,7 @@ public class BastionControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -345,7 +345,7 @@ public class BastionControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperControllerTest.java
@@ -64,13 +64,13 @@ import org.testng.annotations.Test;
 public class BookKeeperControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -86,17 +86,17 @@ public class BookKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: bookkeeper
                             resource-set: bookkeeper
-                          name: pulsarname-bookkeeper
+                          name: pulsar-spec-1-bookkeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: BookKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           BOOKIE_GC: -XX:+UseG1GC
                           BOOKIE_MEM: -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError
@@ -108,7 +108,7 @@ public class BookKeeperControllerTest {
                           PULSAR_PREFIX_reppDnsResolverClass: org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping
                           PULSAR_PREFIX_statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
                           PULSAR_PREFIX_useHostNameAsBookieID: "true"
-                          PULSAR_PREFIX_zkServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_zkServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                         """);
 
         final String service = client
@@ -122,17 +122,17 @@ public class BookKeeperControllerTest {
                     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: bookkeeper
                     resource-set: bookkeeper
-                  name: pulsarname-bookkeeper
+                  name: pulsar-spec-1-bookkeeper
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: BookKeeper
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   clusterIP: None
                   ports:
@@ -141,7 +141,7 @@ public class BookKeeperControllerTest {
                   publishNotReadyAddresses: true
                   selector:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: bookkeeper
                 """);
 
@@ -154,26 +154,26 @@ public class BookKeeperControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: bookkeeper
                     resource-set: bookkeeper
-                  name: pulsarname-bookkeeper
+                  name: pulsar-spec-1-bookkeeper
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: BookKeeper
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   podManagementPolicy: Parallel
                   replicas: 3
                   selector:
                     matchLabels:
                       app: pulsar
-                      cluster: pulsarname
+                      cluster: pulsar-spec-1
                       component: bookkeeper
-                  serviceName: pulsarname-bookkeeper
+                  serviceName: pulsar-spec-1-bookkeeper
                   template:
                     metadata:
                       annotations:
@@ -181,7 +181,7 @@ public class BookKeeperControllerTest {
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: bookkeeper
                         resource-set: bookkeeper
                     spec:
@@ -191,7 +191,7 @@ public class BookKeeperControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: bookkeeper
                             topologyKey: kubernetes.io/hostname
                       containers:
@@ -202,7 +202,7 @@ public class BookKeeperControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-bookkeeper
+                            name: pulsar-spec-1-bookkeeper
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
                         livenessProbe:
@@ -212,7 +212,7 @@ public class BookKeeperControllerTest {
                           initialDelaySeconds: 10
                           periodSeconds: 30
                           timeoutSeconds: 5
-                        name: pulsarname-bookkeeper
+                        name: pulsar-spec-1-bookkeeper
                         ports:
                         - containerPort: 3181
                           name: client
@@ -231,9 +231,9 @@ public class BookKeeperControllerTest {
                             memory: 2Gi
                         volumeMounts:
                         - mountPath: /pulsar/data/bookkeeper/journal
-                          name: pulsarname-bookkeeper-journal
+                          name: pulsar-spec-1-bookkeeper-journal
                         - mountPath: /pulsar/data/bookkeeper/ledgers
-                          name: pulsarname-bookkeeper-ledgers
+                          name: pulsar-spec-1-bookkeeper-ledgers
                       dnsConfig:
                         options:
                         - name: ndots
@@ -246,10 +246,10 @@ public class BookKeeperControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-bookkeeper
+                            name: pulsar-spec-1-bookkeeper
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
-                        name: pulsarname-bookkeeper-metadata-format
+                        name: pulsar-spec-1-bookkeeper-metadata-format
                       securityContext:
                         fsGroup: 0
                       terminationGracePeriodSeconds: 60
@@ -261,10 +261,10 @@ public class BookKeeperControllerTest {
                     metadata:
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: bookkeeper
                         resource-set: bookkeeper
-                      name: pulsarname-bookkeeper-journal
+                      name: pulsar-spec-1-bookkeeper-journal
                     spec:
                       accessModes:
                       - ReadWriteOnce
@@ -276,10 +276,10 @@ public class BookKeeperControllerTest {
                     metadata:
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: bookkeeper
                         resource-set: bookkeeper
-                      name: pulsarname-bookkeeper-ledgers
+                      name: pulsar-spec-1-bookkeeper-ledgers
                     spec:
                       accessModes:
                       - ReadWriteOnce
@@ -299,23 +299,23 @@ public class BookKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: bookkeeper
                             resource-set: bookkeeper
-                          name: pulsarname-bookkeeper
+                          name: pulsar-spec-1-bookkeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: BookKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           maxUnavailable: 1
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: bookkeeper
                             """);
 
@@ -588,7 +588,7 @@ public class BookKeeperControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -610,7 +610,7 @@ public class BookKeeperControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperSetsControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperSetsControllerTest.java
@@ -59,7 +59,7 @@ import org.testng.annotations.Test;
 public class BookKeeperSetsControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
     private BookieAdminClient bookieAdminClient;
     private final ControllerTestUtil<BookKeeperFullSpec, BookKeeper> controllerTestUtil =
             new ControllerTestUtil<>(NAMESPACE, CLUSTER_NAME, this::controllerConstructor);
@@ -73,7 +73,7 @@ public class BookKeeperSetsControllerTest {
     public void testBookKeeperSetsDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     setsUpdateStrategy: Parallel
@@ -85,30 +85,30 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
 
         assertStsEqualsDefault("set1",
-                client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set1").getResource());
+                client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set1").getResource());
 
         assertStsEqualsDefault("set2",
-                client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set2").getResource());
+                client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(ConfigMap.class).size(), 2);
         assertConfigMapEqualsDefault("set1",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set1").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set1").getResource());
         assertConfigMapEqualsDefault("set2",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set2").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(PodDisruptionBudget.class).size(), 2);
 
         assertPdbEqualsDefault("set1",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper-set1").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper-set1").getResource());
         assertPdbEqualsDefault("set2",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper-set2").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 3);
 
         assertServiceEqualsDefault("set1",
-                client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set1").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set1").getResource());
         assertServiceEqualsDefault("set2",
-                client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set2").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set2").getResource());
     }
 
 
@@ -116,7 +116,7 @@ public class BookKeeperSetsControllerTest {
     public void testBookKeeperSetsDefaultName() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     setsUpdateStrategy: Parallel
@@ -141,7 +141,7 @@ public class BookKeeperSetsControllerTest {
     public void testOverride() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     setsUpdateStrategy: Parallel
@@ -168,64 +168,64 @@ public class BookKeeperSetsControllerTest {
         MockKubernetesClient client = invokeController(spec);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 3);
 
-        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set2")
+        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 6);
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "commonvalue");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set2")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "override");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"), "set1");
 
-        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsarname-bookkeeper-set2")
+        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"));
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper-set2")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 1);
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getMetadata()
                 .getAnnotations().get("externaldns"), "myset1");
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set1")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 2);
 
-        Assert.assertNull(client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set2")
+        Assert.assertNull(client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getMetadata()
                 .getAnnotations().get("externaldns"));
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-bookkeeper-set2")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper-set2")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 1);
@@ -234,7 +234,7 @@ public class BookKeeperSetsControllerTest {
     private void assertStsEqualsDefault(String setName, StatefulSet sts) {
         final StatefulSet defaultSts = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(StatefulSet.class).getResource();
         final String resourceName = CLUSTER_NAME + "-bookkeeper-" + setName;
@@ -309,7 +309,7 @@ public class BookKeeperSetsControllerTest {
     private void assertConfigMapEqualsDefault(String setName, ConfigMap cmap) {
         final ConfigMap defaultCmap = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(ConfigMap.class).getResource();
         final String resourceName = CLUSTER_NAME + "-bookkeeper-" + setName;
@@ -328,7 +328,7 @@ public class BookKeeperSetsControllerTest {
     private void assertPdbEqualsDefault(String setName, PodDisruptionBudget pdb) {
         final PodDisruptionBudget defaultPdb = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(PodDisruptionBudget.class).getResource();
         final String resourceName = CLUSTER_NAME + "-bookkeeper-" + setName;
@@ -349,7 +349,7 @@ public class BookKeeperSetsControllerTest {
     private void assertServiceEqualsDefault(String setName, Service service) {
         final Service defaultService = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(Service.class).getResource();
         final String resourceName = CLUSTER_NAME + "-bookkeeper-" + setName;
@@ -416,7 +416,7 @@ public class BookKeeperSetsControllerTest {
     public void testGetBookKeeperSetSpecs() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     replicas: 6
@@ -460,7 +460,7 @@ public class BookKeeperSetsControllerTest {
     public void testRacks() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                     resourceSets:
                         set1norack: {}
@@ -517,7 +517,7 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 6);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set1norack")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set1norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -529,14 +529,14 @@ public class BookKeeperSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: bookkeeper
                                 resource-set: set1norack
                             topologyKey: kubernetes.io/hostname
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set2norack")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set2norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -549,7 +549,7 @@ public class BookKeeperSetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: bookkeeper
                                   resource-set: set2norack
                               topologyKey: kubernetes.io/hostname
@@ -558,21 +558,21 @@ public class BookKeeperSetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: bookkeeper
                                   resource-set: set2norack
                               topologyKey: failure-domain.beta.kubernetes.io/zone
                             weight: 100
                         """);
 
-        Assert.assertNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setdefault")
+        Assert.assertNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setdefault")
                 .getResource()
                 .getSpec()
                 .getTemplate().getSpec().getAffinity()
         );
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set1")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set1")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -605,7 +605,7 @@ public class BookKeeperSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: bookkeeper
                                 rack: rack1
                                 resource-set: set1
@@ -613,7 +613,7 @@ public class BookKeeperSetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set2")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set2")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -645,7 +645,7 @@ public class BookKeeperSetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-set3")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-set3")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -697,7 +697,7 @@ public class BookKeeperSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: bookkeeper
                                 rack: rack3
                                 resource-set: set3
@@ -710,7 +710,7 @@ public class BookKeeperSetsControllerTest {
     public void testRollingUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     sets:
@@ -723,7 +723,7 @@ public class BookKeeperSetsControllerTest {
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
         BookKeeperController.BookKeeperSetsLastApplied setsLastApplied =
                 SerializationUtil.readJson(bookkeeperUpdateControl.getResource().getStatus().getLastApplied(),
                         BookKeeperController.BookKeeperSetsLastApplied.class);
@@ -740,8 +740,8 @@ public class BookKeeperSetsControllerTest {
         Assert.assertNotNull(setsLastApplied.getSets().get("setz"));
 
 
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -752,8 +752,8 @@ public class BookKeeperSetsControllerTest {
                         BookKeeperController.BookKeeperSetsLastApplied.class);
         Assert.assertNotNull(setsLastApplied.getSets().get("seta"));
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -763,14 +763,14 @@ public class BookKeeperSetsControllerTest {
 
         // now update
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", false).build());
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", false).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", false).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", false).build());
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     config:
@@ -783,20 +783,20 @@ public class BookKeeperSetsControllerTest {
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
 
 
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-seta"));
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -809,7 +809,7 @@ public class BookKeeperSetsControllerTest {
     public void testParallelUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     setsUpdateStrategy: Parallel
@@ -822,8 +822,8 @@ public class BookKeeperSetsControllerTest {
         UpdateControl<BookKeeper> bookkeeperUpdateControl = invokeController(spec, new BookKeeper(), client);
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-seta"));
         Assert.assertNotNull(bookkeeperUpdateControl.getResource().getStatus().getLastApplied());
 
 
@@ -833,8 +833,8 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(bookkeeperUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -842,8 +842,8 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(bookkeeperUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -853,14 +853,14 @@ public class BookKeeperSetsControllerTest {
 
         // now update
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", false).build());
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", false).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", false).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", false).build());
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     setsUpdateStrategy: Parallel
@@ -874,13 +874,13 @@ public class BookKeeperSetsControllerTest {
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-seta"));
         Assert.assertNotNull(bookkeeperUpdateControl.getResource().getStatus().getLastApplied());
 
 
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -888,8 +888,8 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(bookkeeperUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-bookkeeper-seta",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-seta", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -902,7 +902,7 @@ public class BookKeeperSetsControllerTest {
     public void testDefineBookKeeperSetWithDefaultName() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     sets:
@@ -919,11 +919,11 @@ public class BookKeeperSetsControllerTest {
         Assert.assertNotNull(setsLastApplied.getSets().get("setz"));
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putResource("pulsarname-bookkeeper-setz",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper-setz", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -935,8 +935,8 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putResource("pulsarname-bookkeeper",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
@@ -946,7 +946,7 @@ public class BookKeeperSetsControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     sets:
@@ -962,16 +962,16 @@ public class BookKeeperSetsControllerTest {
 
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsarname-bookkeeper"));
+        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsar-spec-1-bookkeeper"));
         Assert.assertEquals(client.getDeletedResources().size(), 4);
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper"));
-        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsarname-bookkeeper"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-bookkeeper"));
-        Assert.assertNotNull(client.getDeletedResource(StorageClass.class, "pulsarname-bookkeeper"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper"));
+        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper"));
+        Assert.assertNotNull(client.getDeletedResource(StorageClass.class, "pulsar-spec-1-bookkeeper"));
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     replicas: 0
@@ -987,11 +987,11 @@ public class BookKeeperSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
 
         Assert.assertEquals(client.getDeletedResources().size(), 6);
-        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-bookkeeper-setz"));
-        Assert.assertNotNull(client.getDeletedResource(StorageClass.class, "pulsarname-bookkeeper-setz"));
+        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-bookkeeper-setz"));
+        Assert.assertNotNull(client.getDeletedResource(StorageClass.class, "pulsar-spec-1-bookkeeper-setz"));
     }
 
 
@@ -999,7 +999,7 @@ public class BookKeeperSetsControllerTest {
     public void testCleanupPvc() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     replicas: 4
@@ -1009,20 +1009,20 @@ public class BookKeeperSetsControllerTest {
         UpdateControl<BookKeeper> bookkeeperUpdateControl = invokeController(spec, new BookKeeper(), client);
         KubeTestUtil.assertUpdateControlInitializing(bookkeeperUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-bookkeeper"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-bookkeeper"));
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putResource("pulsarname-bookkeeper",
-                resolver.newStatefulSetBuilder("pulsarname-bookkeeper", true).build());
+        resolver.putResource("pulsar-spec-1-bookkeeper",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-bookkeeper", true).build());
 
-        resolver.putResource("pulsarname-bookkeeper-journal-0", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-ledgers-0", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-journal-1", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-ledgers-1", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-journal-2", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-ledgers-2", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-journal-3", genPvc());
-        resolver.putResource("pulsarname-bookkeeper-ledgers-3", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-journal-0", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-ledgers-0", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-journal-1", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-ledgers-1", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-journal-2", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-ledgers-2", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-journal-3", genPvc());
+        resolver.putResource("pulsar-spec-1-bookkeeper-ledgers-3", genPvc());
         client = new MockKubernetesClient(NAMESPACE, resolver);
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlReady(bookkeeperUpdateControl);
@@ -1031,7 +1031,7 @@ public class BookKeeperSetsControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     replicas: 2
@@ -1041,15 +1041,15 @@ public class BookKeeperSetsControllerTest {
         bookkeeperUpdateControl = invokeController(spec, bookkeeperUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlReady(bookkeeperUpdateControl);
         Assert.assertEquals(client.getDeletedResources().size(), 4);
-        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsarname-bookkeeper-ledgers-2"));
-        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsarname-bookkeeper-journal-2"));
-        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsarname-bookkeeper-ledgers-3"));
-        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsarname-bookkeeper-journal-3"));
+        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsar-spec-1-bookkeeper-ledgers-2"));
+        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsar-spec-1-bookkeeper-journal-2"));
+        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsar-spec-1-bookkeeper-ledgers-3"));
+        Assert.assertNotNull(client.getDeletedResource(PersistentVolumeClaim.class, "pulsar-spec-1-bookkeeper-journal-3"));
 
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 bookkeeper:
                     cleanUpPvcs: false
@@ -1067,7 +1067,7 @@ public class BookKeeperSetsControllerTest {
         return new PersistentVolumeClaimBuilder()
                 .withNewMetadata()
                 .withLabels(Map.of(CRDConstants.LABEL_APP, "pulsar",
-                        CRDConstants.LABEL_CLUSTER, "pulsarname",
+                        CRDConstants.LABEL_CLUSTER, "pulsar-spec-1",
                         CRDConstants.LABEL_COMPONENT, "bookkeeper",
                         CRDConstants.LABEL_RESOURCESET, "bookkeeper"))
                 .endMetadata()

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerControllerTest.java
@@ -60,7 +60,7 @@ import org.testng.annotations.Test;
 public class BrokerControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
     private final ControllerTestUtil<BrokerFullSpec, Broker> controllerTestUtil =
             new ControllerTestUtil<>(NAMESPACE, CLUSTER_NAME);
 
@@ -68,7 +68,7 @@ public class BrokerControllerTest {
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -84,17 +84,17 @@ public class BrokerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: broker
                             resource-set: broker
-                          name: pulsarname-broker
+                          name: pulsar-spec-1-broker
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Broker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
@@ -104,11 +104,11 @@ public class BrokerControllerTest {
                           PULSAR_PREFIX_backlogQuotaDefaultRetentionPolicy: producer_exception
                           PULSAR_PREFIX_bookkeeperClientRegionawarePolicyEnabled: "true"
                           PULSAR_PREFIX_brokerDeduplicationEnabled: "false"
-                          PULSAR_PREFIX_clusterName: pulsarname
-                          PULSAR_PREFIX_configurationStoreServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_clusterName: pulsar-spec-1
+                          PULSAR_PREFIX_configurationStoreServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                           PULSAR_PREFIX_exposeConsumerLevelMetricsInPrometheus: "false"
                           PULSAR_PREFIX_exposeTopicLevelMetricsInPrometheus: "true"
-                          PULSAR_PREFIX_zookeeperServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_zookeeperServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                         """);
 
         final String service = client
@@ -120,17 +120,17 @@ public class BrokerControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: broker
                     resource-set: broker
-                  name: pulsarname-broker
+                  name: pulsar-spec-1-broker
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Broker
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   clusterIP: None
                   ports:
@@ -140,7 +140,7 @@ public class BrokerControllerTest {
                     port: 6650
                   selector:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: broker
                   type: ClusterIP
                 """);
@@ -154,25 +154,25 @@ public class BrokerControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: broker
                     resource-set: broker
-                  name: pulsarname-broker
+                  name: pulsar-spec-1-broker
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Broker
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   replicas: 3
                   selector:
                     matchLabels:
                       app: pulsar
-                      cluster: pulsarname
+                      cluster: pulsar-spec-1
                       component: broker
-                  serviceName: pulsarname-broker
+                  serviceName: pulsar-spec-1-broker
                   template:
                     metadata:
                       annotations:
@@ -180,7 +180,7 @@ public class BrokerControllerTest {
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: broker
                         resource-set: broker
                     spec:
@@ -190,7 +190,7 @@ public class BrokerControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: broker
                             topologyKey: kubernetes.io/hostname
                       containers:
@@ -201,7 +201,7 @@ public class BrokerControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-broker
+                            name: pulsar-spec-1-broker
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
                         livenessProbe:
@@ -213,7 +213,7 @@ public class BrokerControllerTest {
                           initialDelaySeconds: 10
                           periodSeconds: 30
                           timeoutSeconds: 5
-                        name: pulsarname-broker
+                        name: pulsar-spec-1-broker
                         ports:
                         - containerPort: 8080
                           name: http
@@ -250,23 +250,23 @@ public class BrokerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: broker
                             resource-set: broker
-                          name: pulsarname-broker
+                          name: pulsar-spec-1-broker
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Broker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           maxUnavailable: 1
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: broker
                             """);
 
@@ -388,7 +388,7 @@ public class BrokerControllerTest {
                             kind: Broker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           template:
                             metadata:
@@ -799,7 +799,7 @@ public class BrokerControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -821,7 +821,7 @@ public class BrokerControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerSetsControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/broker/BrokerSetsControllerTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.Test;
 public class BrokerSetsControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
     private final ControllerTestUtil<BrokerFullSpec, Broker> controllerTestUtil =
             new ControllerTestUtil<>(NAMESPACE, CLUSTER_NAME);
 
@@ -47,7 +47,7 @@ public class BrokerSetsControllerTest {
     public void testBrokerSetsDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     setsUpdateStrategy: Parallel
@@ -59,30 +59,30 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
 
         assertStsEqualsDefault("set1",
-                client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set1").getResource());
+                client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set1").getResource());
 
         assertStsEqualsDefault("set2",
-                client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set2").getResource());
+                client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(ConfigMap.class).size(), 2);
         assertConfigMapEqualsDefault("set1",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set1").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set1").getResource());
         assertConfigMapEqualsDefault("set2",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set2").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(PodDisruptionBudget.class).size(), 2);
 
         assertPdbEqualsDefault("set1",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-broker-set1").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker-set1").getResource());
         assertPdbEqualsDefault("set2",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-broker-set2").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 3);
 
         assertServiceEqualsDefault("set1",
-                client.getCreatedResource(Service.class, "pulsarname-broker-set1").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set1").getResource());
         assertServiceEqualsDefault("set2",
-                client.getCreatedResource(Service.class, "pulsarname-broker-set2").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set2").getResource());
     }
 
 
@@ -90,7 +90,7 @@ public class BrokerSetsControllerTest {
     public void testOverride() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     setsUpdateStrategy: Parallel
@@ -117,64 +117,64 @@ public class BrokerSetsControllerTest {
         MockKubernetesClient client = invokeController(spec);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 3);
 
-        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set2")
+        Assert.assertEquals(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 6);
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "commonvalue");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set2")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "override");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"), "set1");
 
-        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsarname-broker-set2")
+        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"));
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-broker-set2")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 1);
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getMetadata()
                 .getAnnotations().get("externaldns"), "myset1");
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-broker-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set1")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 3);
 
-        Assert.assertNull(client.getCreatedResource(Service.class, "pulsarname-broker-set2")
+        Assert.assertNull(client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getMetadata()
                 .getAnnotations());
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-broker-set2")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-broker-set2")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 2);
@@ -183,7 +183,7 @@ public class BrokerSetsControllerTest {
     private void assertStsEqualsDefault(String setName, StatefulSet sts) {
         final StatefulSet defaultSts = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(StatefulSet.class).getResource();
         final String resourceName = CLUSTER_NAME + "-broker-" + setName;
@@ -225,7 +225,7 @@ public class BrokerSetsControllerTest {
     private void assertConfigMapEqualsDefault(String setName, ConfigMap cmap) {
         final ConfigMap defaultCmap = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(ConfigMap.class).getResource();
         final String resourceName = CLUSTER_NAME + "-broker-" + setName;
@@ -244,7 +244,7 @@ public class BrokerSetsControllerTest {
     private void assertPdbEqualsDefault(String setName, PodDisruptionBudget pdb) {
         final PodDisruptionBudget defaultPdb = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(PodDisruptionBudget.class).getResource();
         final String resourceName = CLUSTER_NAME + "-broker-" + setName;
@@ -265,7 +265,7 @@ public class BrokerSetsControllerTest {
     private void assertServiceEqualsDefault(String setName, Service service) {
         final Service defaultService = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(Service.class).getResource();
         final String resourceName = CLUSTER_NAME + "-broker-" + setName;
@@ -324,7 +324,7 @@ public class BrokerSetsControllerTest {
     public void testGetBrokerSetSpecs() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     replicas: 6
@@ -367,7 +367,7 @@ public class BrokerSetsControllerTest {
     public void testRacks() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                     resourceSets:
                         set1norack: {}
@@ -424,7 +424,7 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 6);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set1norack")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set1norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -436,14 +436,14 @@ public class BrokerSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: broker
                                 resource-set: set1norack
                             topologyKey: kubernetes.io/hostname
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set2norack")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set2norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -456,7 +456,7 @@ public class BrokerSetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: broker
                                   resource-set: set2norack
                               topologyKey: kubernetes.io/hostname
@@ -465,21 +465,21 @@ public class BrokerSetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: broker
                                   resource-set: set2norack
                               topologyKey: failure-domain.beta.kubernetes.io/zone
                             weight: 100
                         """);
 
-        Assert.assertNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setdefault")
+        Assert.assertNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setdefault")
                 .getResource()
                 .getSpec()
                 .getTemplate().getSpec().getAffinity()
         );
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set1")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set1")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -512,7 +512,7 @@ public class BrokerSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: broker
                                 rack: rack1
                                 resource-set: set1
@@ -520,7 +520,7 @@ public class BrokerSetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set2")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set2")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -552,7 +552,7 @@ public class BrokerSetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(StatefulSet.class, "pulsarname-broker-set3")
+                        client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-set3")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -604,7 +604,7 @@ public class BrokerSetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: broker
                                 rack: rack3
                                 resource-set: set3
@@ -617,7 +617,7 @@ public class BrokerSetsControllerTest {
     public void testRollingUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     sets:
@@ -634,7 +634,7 @@ public class BrokerSetsControllerTest {
         Assert.assertNotNull(setsLastApplied.getSets().get("setz"));
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
 
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
@@ -642,8 +642,8 @@ public class BrokerSetsControllerTest {
         KubeTestUtil.assertUpdateControlInitializing(brokerUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
 
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", true).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -655,8 +655,8 @@ public class BrokerSetsControllerTest {
                         BrokerController.BrokerSetsLastApplied.class);
         Assert.assertNotNull(setsLastApplied.getSets().get("seta"));
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", true).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -666,14 +666,14 @@ public class BrokerSetsControllerTest {
 
         // now update
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", false).build());
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", false).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", false).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", false).build());
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     config:
@@ -686,21 +686,21 @@ public class BrokerSetsControllerTest {
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(brokerUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
 
 
 
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", true).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(brokerUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-seta"));
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", true).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -713,7 +713,7 @@ public class BrokerSetsControllerTest {
     public void testParallelUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     setsUpdateStrategy: Parallel
@@ -726,8 +726,8 @@ public class BrokerSetsControllerTest {
         UpdateControl<Broker> brokerUpdateControl = invokeController(spec, new Broker(), client);
         KubeTestUtil.assertUpdateControlInitializing(brokerUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setz"));
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-seta"));
         Assert.assertNotNull(brokerUpdateControl.getResource().getStatus().getLastApplied());
 
 
@@ -737,8 +737,8 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(brokerUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", true).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -746,8 +746,8 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(brokerUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", true).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -757,14 +757,14 @@ public class BrokerSetsControllerTest {
 
         // now update
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", false).build());
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", false).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", false).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", false).build());
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     setsUpdateStrategy: Parallel
@@ -778,13 +778,13 @@ public class BrokerSetsControllerTest {
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(brokerUpdateControl);
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setz"));
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-seta"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-seta"));
         Assert.assertNotNull(brokerUpdateControl.getResource().getStatus().getLastApplied());
 
 
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", true).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -792,8 +792,8 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertNotNull(brokerUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putResource("pulsarname-broker-seta",
-                resolver.newStatefulSetBuilder("pulsarname-broker-seta", true).build());
+        resolver.putResource("pulsar-spec-1-broker-seta",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-seta", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -806,7 +806,7 @@ public class BrokerSetsControllerTest {
     public void testDefineBrokerSetWithDefaultName() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     sets:
@@ -823,11 +823,11 @@ public class BrokerSetsControllerTest {
         Assert.assertNotNull(setsLastApplied.getSets().get("setz"));
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsarname-broker-setz"));
+        Assert.assertNotNull(client.getCreatedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putResource("pulsarname-broker-setz",
-                resolver.newStatefulSetBuilder("pulsarname-broker-setz", true).build());
+        resolver.putResource("pulsar-spec-1-broker-setz",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker-setz", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -839,8 +839,8 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 1);
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putResource("pulsarname-broker",
-                resolver.newStatefulSetBuilder("pulsarname-broker", true).build());
+        resolver.putResource("pulsar-spec-1-broker",
+                resolver.newStatefulSetBuilder("pulsar-spec-1-broker", true).build());
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         brokerUpdateControl = invokeController(spec, brokerUpdateControl.getResource(), client);
@@ -851,7 +851,7 @@ public class BrokerSetsControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     sets:
@@ -866,15 +866,15 @@ public class BrokerSetsControllerTest {
         Assert.assertNull(setsLastApplied.getSets().get("broker"));
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsarname-broker"));
+        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsar-spec-1-broker"));
         Assert.assertEquals(client.getDeletedResources().size(), 3);
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-broker"));
-        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsarname-broker"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-broker"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker"));
+        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsar-spec-1-broker"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-broker"));
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 broker:
                     replicas: 0
@@ -890,9 +890,9 @@ public class BrokerSetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(StatefulSet.class).size(), 0);
 
         Assert.assertEquals(client.getDeletedResources().size(), 5);
-        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsarname-broker-setz"));
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-broker-setz"));
-        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsarname-broker-setz"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-broker-setz"));
+        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsar-spec-1-broker-setz"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-broker-setz"));
+        Assert.assertNotNull(client.getDeletedResource(StatefulSet.class, "pulsar-spec-1-broker-setz"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-broker-setz"));
     }
 }

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerControllerTest.java
@@ -68,13 +68,13 @@ import org.testng.annotations.Test;
 public class FunctionsWorkerControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 functionsWorker:
                     replicas: 2
@@ -90,22 +90,22 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           functions_worker.yml: |
                             ---
                             assignmentWriteMaxRetries: 60
                             clusterCoordinationTopicName: coordinate
-                            configurationStoreServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                            configurationStoreServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                             connectorsDirectory: ./connectors
                             downloadDirectory: /tmp/pulsar_functions
                             failureCheckFreqMs: 30000
@@ -118,18 +118,18 @@ public class FunctionsWorkerControllerTest {
                             instanceLivenessCheckFreqMs: 30000
                             numFunctionPackageReplicas: 2
                             numHttpServerThreads: 16
-                            pulsarFunctionsCluster: pulsarname
+                            pulsarFunctionsCluster: pulsar-spec-1
                             pulsarFunctionsNamespace: public/functions
-                            pulsarServiceUrl: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
-                            pulsarWebServiceUrl: http://pulsarname-broker.ns.svc.cluster.local:8080/
+                            pulsarServiceUrl: pulsar://pulsar-spec-1-broker.ns.svc.cluster.local:6650/
+                            pulsarWebServiceUrl: http://pulsar-spec-1-broker.ns.svc.cluster.local:8080/
                             rescheduleTimeoutMs: 60000
                             schedulerClassName: org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler
                             topicCompactionFrequencySec: 1800
-                            workerHostname: pulsarname-function
-                            workerId: pulsarname-function
+                            workerHostname: pulsar-spec-1-function
+                            workerId: pulsar-spec-1-function
                             workerPort: 6750
                             zooKeeperSessionTimeoutMillis: 30000
-                            zookeeperServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                            zookeeperServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                                                 """);
 
         Assert.assertEquals(client.getCreatedResources(ConfigMap.class).get(1).getResourceYaml(),
@@ -140,16 +140,16 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function-extra
+                          name: pulsar-spec-1-function-extra
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
@@ -165,16 +165,16 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function-ca
+                          name: pulsar-spec-1-function-ca
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           ports:
                           - name: http
@@ -183,7 +183,7 @@ public class FunctionsWorkerControllerTest {
                             port: 6751
                           selector:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
                         """);
 
@@ -195,16 +195,16 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           clusterIP: None
                           ports:
@@ -214,7 +214,7 @@ public class FunctionsWorkerControllerTest {
                             port: 6751
                           selector:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
                           type: ClusterIP
                         """);
@@ -227,25 +227,25 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           podManagementPolicy: Parallel
                           replicas: 2
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: function
-                          serviceName: pulsarname-function
+                          serviceName: pulsar-spec-1-function
                           template:
                             metadata:
                               annotations:
@@ -253,7 +253,7 @@ public class FunctionsWorkerControllerTest {
                                 prometheus.io/scrape: "true"
                               labels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: function
                             spec:
                               affinity:
@@ -262,12 +262,12 @@ public class FunctionsWorkerControllerTest {
                                   - labelSelector:
                                       matchLabels:
                                         app: pulsar
-                                        cluster: pulsarname
+                                        cluster: pulsar-spec-1
                                         component: function
                                     topologyKey: kubernetes.io/hostname
                               containers:
                               - args:
-                                - "bin/apply-config-from-env.py conf/broker.conf && cp -f funcconf/functions_worker.yml conf/functions_worker.yml && export PF_workerHostname=\\"${workerHostname}.pulsarname-function\\" && bin/gen-yml-from-env.py conf/functions_worker.yml && OPTS=\\"${OPTS} -Dlog4j2.formatMsgNoLookups=true\\" exec bin/pulsar functions-worker"
+                                - "bin/apply-config-from-env.py conf/broker.conf && cp -f funcconf/functions_worker.yml conf/functions_worker.yml && export PF_workerHostname=\\"${workerHostname}.pulsar-spec-1-function\\" && bin/gen-yml-from-env.py conf/functions_worker.yml && OPTS=\\"${OPTS} -Dlog4j2.formatMsgNoLookups=true\\" exec bin/pulsar functions-worker"
                                 command:
                                 - sh
                                 - -c
@@ -282,7 +282,7 @@ public class FunctionsWorkerControllerTest {
                                       fieldPath: metadata.name
                                 envFrom:
                                 - configMapRef:
-                                    name: pulsarname-function-extra
+                                    name: pulsar-spec-1-function-extra
                                 image: apachepulsar/pulsar:2.10.2
                                 imagePullPolicy: IfNotPresent
                                 livenessProbe:
@@ -294,7 +294,7 @@ public class FunctionsWorkerControllerTest {
                                   initialDelaySeconds: 10
                                   periodSeconds: 30
                                   timeoutSeconds: 5
-                                name: pulsarname-function
+                                name: pulsar-spec-1-function
                                 ports:
                                 - containerPort: 6750
                                   name: http
@@ -315,18 +315,18 @@ public class FunctionsWorkerControllerTest {
                                   name: config-volume
                                   subPath: functions_worker.yml
                                 - mountPath: /pulsar/logs
-                                  name: pulsarname-function-logs
+                                  name: pulsar-spec-1-function-logs
                               dnsConfig:
                                 options:
                                 - name: ndots
                                   value: 4
                               securityContext:
                                 fsGroup: 0
-                              serviceAccountName: pulsarname-function
+                              serviceAccountName: pulsar-spec-1-function
                               terminationGracePeriodSeconds: 60
                               volumes:
                               - configMap:
-                                  name: pulsarname-function
+                                  name: pulsar-spec-1-function
                                 name: config-volume
                           updateStrategy:
                             type: RollingUpdate
@@ -336,9 +336,9 @@ public class FunctionsWorkerControllerTest {
                             metadata:
                               labels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: function
-                              name: pulsarname-function-logs
+                              name: pulsar-spec-1-function-logs
                             spec:
                               accessModes:
                               - ReadWriteOnce
@@ -355,22 +355,22 @@ public class FunctionsWorkerControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: function
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           maxUnavailable: 1
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: function
                         """);
 
@@ -380,14 +380,14 @@ public class FunctionsWorkerControllerTest {
                         apiVersion: v1
                         kind: ServiceAccount
                         metadata:
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         """);
         Assert.assertEquals(client.getCreatedResource(Role.class).getResourceYaml(),
                 """
@@ -395,14 +395,14 @@ public class FunctionsWorkerControllerTest {
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
                         metadata:
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         rules:
                         - apiGroups:
                           - ""
@@ -439,20 +439,20 @@ public class FunctionsWorkerControllerTest {
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
                         metadata:
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         roleRef:
                           kind: Role
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                         subjects:
                         - kind: ServiceAccount
-                          name: pulsarname-function
+                          name: pulsar-spec-1-function
                           namespace: ns
                         """);
     }
@@ -461,7 +461,7 @@ public class FunctionsWorkerControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -485,7 +485,7 @@ public class FunctionsWorkerControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -2143,7 +2143,7 @@ public class FunctionsWorkerControllerTest {
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         """);
         Assert.assertEquals(client.getCreatedResource(ClusterRole.class).getResourceYaml(),
                 """
@@ -2157,7 +2157,7 @@ public class FunctionsWorkerControllerTest {
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         rules:
                         - apiGroups:
                           - ""
@@ -2200,7 +2200,7 @@ public class FunctionsWorkerControllerTest {
                             kind: FunctionsWorker
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         roleRef:
                           kind: ClusterRole
                           name: pul-function

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxyControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxyControllerTest.java
@@ -57,13 +57,13 @@ import org.testng.annotations.Test;
 public class ProxyControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -78,29 +78,29 @@ public class ProxyControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: proxy
                             resource-set: proxy
-                          name: pulsarname-proxy
+                          name: pulsar-spec-1-proxy
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Proxy
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_PREFIX_brokerServiceURL: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
-                          PULSAR_PREFIX_brokerServiceURLTLS: pulsar+ssl://pulsarname-broker.ns.svc.cluster.local:6651/
-                          PULSAR_PREFIX_brokerWebServiceURL: http://pulsarname-broker.ns.svc.cluster.local:8080/
-                          PULSAR_PREFIX_brokerWebServiceURLTLS: https://pulsarname-broker.ns.svc.cluster.local:8443/
-                          PULSAR_PREFIX_clusterName: pulsarname
-                          PULSAR_PREFIX_configurationStoreServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_brokerServiceURL: pulsar://pulsar-spec-1-broker.ns.svc.cluster.local:6650/
+                          PULSAR_PREFIX_brokerServiceURLTLS: pulsar+ssl://pulsar-spec-1-broker.ns.svc.cluster.local:6651/
+                          PULSAR_PREFIX_brokerWebServiceURL: http://pulsar-spec-1-broker.ns.svc.cluster.local:8080/
+                          PULSAR_PREFIX_brokerWebServiceURLTLS: https://pulsar-spec-1-broker.ns.svc.cluster.local:8443/
+                          PULSAR_PREFIX_clusterName: pulsar-spec-1
+                          PULSAR_PREFIX_configurationStoreServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                           PULSAR_PREFIX_numHttpServerThreads: 10
-                          PULSAR_PREFIX_zookeeperServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_zookeeperServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                         """);
 
         Assert.assertEquals(client
@@ -112,30 +112,30 @@ public class ProxyControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: proxy
                             resource-set: proxy
-                          name: pulsarname-proxy-ws
+                          name: pulsar-spec-1-proxy-ws
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Proxy
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
                           PULSAR_LOG_ROOT_LEVEL: info
-                          PULSAR_PREFIX_brokerServiceUrl: pulsar://pulsarname-broker.ns.svc.cluster.local:6650/
-                          PULSAR_PREFIX_brokerServiceUrlTls: pulsar+ssl://pulsarname-broker.ns.svc.cluster.local:6651/
-                          PULSAR_PREFIX_clusterName: pulsarname
-                          PULSAR_PREFIX_configurationStoreServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_brokerServiceUrl: pulsar://pulsar-spec-1-broker.ns.svc.cluster.local:6650/
+                          PULSAR_PREFIX_brokerServiceUrlTls: pulsar+ssl://pulsar-spec-1-broker.ns.svc.cluster.local:6651/
+                          PULSAR_PREFIX_clusterName: pulsar-spec-1
+                          PULSAR_PREFIX_configurationStoreServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                           PULSAR_PREFIX_numHttpServerThreads: 10
-                          PULSAR_PREFIX_serviceUrl: http://pulsarname-broker.ns.svc.cluster.local:8080/
-                          PULSAR_PREFIX_serviceUrlTls: https://pulsarname-broker.ns.svc.cluster.local:8443/
+                          PULSAR_PREFIX_serviceUrl: http://pulsar-spec-1-broker.ns.svc.cluster.local:8080/
+                          PULSAR_PREFIX_serviceUrlTls: https://pulsar-spec-1-broker.ns.svc.cluster.local:8443/
                           PULSAR_PREFIX_webServicePort: 8000
-                          PULSAR_PREFIX_zookeeperServers: pulsarname-zookeeper-ca.ns.svc.cluster.local:2181
+                          PULSAR_PREFIX_zookeeperServers: pulsar-spec-1-zookeeper-ca.ns.svc.cluster.local:2181
                         """);
 
         final String service = client
@@ -147,17 +147,17 @@ public class ProxyControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: proxy
                     resource-set: proxy
-                  name: pulsarname-proxy
+                  name: pulsar-spec-1-proxy
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Proxy
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   ports:
                   - name: http
@@ -168,7 +168,7 @@ public class ProxyControllerTest {
                     port: 8000
                   selector:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: proxy
                   type: LoadBalancer
                 """);
@@ -182,23 +182,23 @@ public class ProxyControllerTest {
                 metadata:
                   labels:
                     app: pulsar
-                    cluster: pulsarname
+                    cluster: pulsar-spec-1
                     component: proxy
                     resource-set: proxy
-                  name: pulsarname-proxy
+                  name: pulsar-spec-1-proxy
                   namespace: ns
                   ownerReferences:
                   - apiVersion: kaap.oss.datastax.com/v1alpha1
                     kind: Proxy
                     blockOwnerDeletion: true
                     controller: true
-                    name: pulsarname-cr
+                    name: pulsar-spec-1-cr
                 spec:
                   replicas: 3
                   selector:
                     matchLabels:
                       app: pulsar
-                      cluster: pulsarname
+                      cluster: pulsar-spec-1
                       component: proxy
                   strategy:
                     rollingUpdate:
@@ -212,7 +212,7 @@ public class ProxyControllerTest {
                         prometheus.io/scrape: "true"
                       labels:
                         app: pulsar
-                        cluster: pulsarname
+                        cluster: pulsar-spec-1
                         component: proxy
                         resource-set: proxy
                     spec:
@@ -222,7 +222,7 @@ public class ProxyControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: proxy
                             topologyKey: kubernetes.io/hostname
                       containers:
@@ -233,7 +233,7 @@ public class ProxyControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-proxy
+                            name: pulsar-spec-1-proxy
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
                         livenessProbe:
@@ -245,7 +245,7 @@ public class ProxyControllerTest {
                           initialDelaySeconds: 10
                           periodSeconds: 30
                           timeoutSeconds: 5
-                        name: pulsarname-proxy
+                        name: pulsar-spec-1-proxy
                         ports:
                         - containerPort: 8080
                           name: http
@@ -271,10 +271,10 @@ public class ProxyControllerTest {
                         - -c
                         envFrom:
                         - configMapRef:
-                            name: pulsarname-proxy-ws
+                            name: pulsar-spec-1-proxy-ws
                         image: apachepulsar/pulsar:2.10.2
                         imagePullPolicy: IfNotPresent
-                        name: pulsarname-proxy-ws
+                        name: pulsar-spec-1-proxy-ws
                         ports:
                         - containerPort: 8000
                           name: ws
@@ -300,23 +300,23 @@ public class ProxyControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: proxy
                             resource-set: proxy
-                          name: pulsarname-proxy
+                          name: pulsar-spec-1-proxy
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: Proxy
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           maxUnavailable: 1
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: proxy
                             """);
 
@@ -687,7 +687,7 @@ public class ProxyControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -709,7 +709,7 @@ public class ProxyControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxySetsControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/proxy/ProxySetsControllerTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 public class ProxySetsControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
     private final ControllerTestUtil<ProxyFullSpec, Proxy> controllerTestUtil =
             new ControllerTestUtil<>(NAMESPACE, CLUSTER_NAME);
 
@@ -45,7 +45,7 @@ public class ProxySetsControllerTest {
     public void testProxySetsDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     setsUpdateStrategy: Parallel
@@ -57,30 +57,30 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 2);
 
         assertDeploymentEqualsDefault("set1",
-                client.getCreatedResource(Deployment.class, "pulsarname-proxy-set1").getResource());
+                client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set1").getResource());
 
         assertDeploymentEqualsDefault("set2",
-                client.getCreatedResource(Deployment.class, "pulsarname-proxy-set2").getResource());
+                client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(ConfigMap.class).size(), 4);
         assertConfigMapEqualsDefault("set1",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set1").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set1").getResource());
         assertConfigMapEqualsDefault("set2",
-                client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set2").getResource());
+                client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(PodDisruptionBudget.class).size(), 2);
 
         assertPdbEqualsDefault("set1",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-proxy-set1").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy-set1").getResource());
         assertPdbEqualsDefault("set2",
-                client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-proxy-set2").getResource());
+                client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy-set2").getResource());
 
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 3);
 
         assertServiceEqualsDefault("set1",
-                client.getCreatedResource(Service.class, "pulsarname-proxy-set1").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set1").getResource());
         assertServiceEqualsDefault("set2",
-                client.getCreatedResource(Service.class, "pulsarname-proxy-set2").getResource());
+                client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set2").getResource());
     }
 
 
@@ -88,7 +88,7 @@ public class ProxySetsControllerTest {
     public void testOverride() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     setsUpdateStrategy: Parallel
@@ -115,64 +115,64 @@ public class ProxySetsControllerTest {
         MockKubernetesClient client = invokeController(spec);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(Deployment.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 3);
 
-        Assert.assertEquals(client.getCreatedResource(Deployment.class, "pulsarname-proxy-set2")
+        Assert.assertEquals(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getSpec()
                 .getReplicas(), 6);
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "commonvalue");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set2")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_common"), "override");
 
-        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"), "set1");
 
-        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsarname-proxy-set2")
+        Assert.assertNull(client.getCreatedResource(ConfigMap.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getData()
                 .get("PULSAR_PREFIX_myname"));
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 2);
 
-        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsarname-proxy-set2")
+        Assert.assertEquals(client.getCreatedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getSpec()
                 .getMaxUnavailable()
                 .getIntVal(), 1);
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getMetadata()
                 .getAnnotations().get("externaldns"), "myset1");
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-proxy-set1")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set1")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 4);
 
-        Assert.assertNull(client.getCreatedResource(Service.class, "pulsarname-proxy-set2")
+        Assert.assertNull(client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getMetadata()
                 .getAnnotations());
 
-        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsarname-proxy-set2")
+        Assert.assertEquals(client.getCreatedResource(Service.class, "pulsar-spec-1-proxy-set2")
                 .getResource()
                 .getSpec()
                 .getPorts().size(), 3);
@@ -181,7 +181,7 @@ public class ProxySetsControllerTest {
     private void assertDeploymentEqualsDefault(String setName, Deployment deployment) {
         final Deployment defaultSts = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(Deployment.class).getResource();
         final String resourceName = CLUSTER_NAME + "-proxy-" + setName;
@@ -226,7 +226,7 @@ public class ProxySetsControllerTest {
     private void assertConfigMapEqualsDefault(String setName, ConfigMap cmap) {
         final ConfigMap defaultCmap = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(ConfigMap.class).getResource();
         final String resourceName = CLUSTER_NAME + "-proxy-" + setName;
@@ -245,7 +245,7 @@ public class ProxySetsControllerTest {
     private void assertPdbEqualsDefault(String setName, PodDisruptionBudget pdb) {
         final PodDisruptionBudget defaultPdb = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(PodDisruptionBudget.class).getResource();
         final String resourceName = CLUSTER_NAME + "-proxy-" + setName;
@@ -266,7 +266,7 @@ public class ProxySetsControllerTest {
     private void assertServiceEqualsDefault(String setName, Service service) {
         final Service defaultService = invokeController("""
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 """).getCreatedResource(Service.class).getResource();
         final String resourceName = CLUSTER_NAME + "-proxy-" + setName;
@@ -309,7 +309,7 @@ public class ProxySetsControllerTest {
     public void testRacks() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                     resourceSets:
                         set1norack: {}
@@ -366,7 +366,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 6);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(Deployment.class, "pulsarname-proxy-set1norack")
+                        client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set1norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -378,14 +378,14 @@ public class ProxySetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: proxy
                                 resource-set: set1norack
                             topologyKey: kubernetes.io/hostname
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(Deployment.class, "pulsarname-proxy-set2norack")
+                        client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set2norack")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -398,7 +398,7 @@ public class ProxySetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: proxy
                                   resource-set: set2norack
                               topologyKey: kubernetes.io/hostname
@@ -407,21 +407,21 @@ public class ProxySetsControllerTest {
                               labelSelector:
                                 matchLabels:
                                   app: pulsar
-                                  cluster: pulsarname
+                                  cluster: pulsar-spec-1
                                   component: proxy
                                   resource-set: set2norack
                               topologyKey: failure-domain.beta.kubernetes.io/zone
                             weight: 100
                         """);
 
-        Assert.assertNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setdefault")
+        Assert.assertNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setdefault")
                 .getResource()
                 .getSpec()
                 .getTemplate().getSpec().getAffinity()
         );
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(Deployment.class, "pulsarname-proxy-set1")
+                        client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set1")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -454,7 +454,7 @@ public class ProxySetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: proxy
                                 rack: rack1
                                 resource-set: set1
@@ -462,7 +462,7 @@ public class ProxySetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(Deployment.class, "pulsarname-proxy-set2")
+                        client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set2")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -494,7 +494,7 @@ public class ProxySetsControllerTest {
                         """);
 
         Assert.assertEquals(SerializationUtil.writeAsYaml(
-                        client.getCreatedResource(Deployment.class, "pulsarname-proxy-set3")
+                        client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-set3")
                                 .getResource()
                                 .getSpec()
                                 .getTemplate().getSpec().getAffinity()
@@ -546,7 +546,7 @@ public class ProxySetsControllerTest {
                           - labelSelector:
                               matchLabels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: proxy
                                 rack: rack3
                                 resource-set: set3
@@ -564,7 +564,7 @@ public class ProxySetsControllerTest {
     public void testRollingUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     sets:
@@ -580,7 +580,7 @@ public class ProxySetsControllerTest {
                         ProxyController.ProxySetsLastApplied.class);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setz"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
         Assert.assertNotNull(proxySetsLastApplied.getCommon());
         Assert.assertNotNull(proxySetsLastApplied.getSets().get("setz"));
 
@@ -594,7 +594,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertNotNull(proxySetsLastApplied.getSets().get("setz"));
 
-        resolver.putDeployment("pulsarname-proxy-setz", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -605,7 +605,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 1);
         Assert.assertNotNull(proxySetsLastApplied.getSets().get("seta"));
 
-        resolver.putDeployment("pulsarname-proxy-seta", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -615,12 +615,12 @@ public class ProxySetsControllerTest {
 
         // now update
 
-        resolver.putDeployment("pulsarname-proxy-setz", false);
-        resolver.putDeployment("pulsarname-proxy-seta", false);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", false);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", false);
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     config:
@@ -633,18 +633,18 @@ public class ProxySetsControllerTest {
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(proxyUpdateControl);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setz"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
 
 
-        resolver.putDeployment("pulsarname-proxy-setz", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(proxyUpdateControl);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-seta"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-seta"));
 
-        resolver.putDeployment("pulsarname-proxy-seta", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -656,7 +656,7 @@ public class ProxySetsControllerTest {
     public void testParallelUpdate() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     setsUpdateStrategy: Parallel
@@ -669,8 +669,8 @@ public class ProxySetsControllerTest {
         UpdateControl<Proxy> proxyUpdateControl = invokeController(spec, new Proxy(), client);
         KubeTestUtil.assertUpdateControlInitializing(proxyUpdateControl);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-seta"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-seta"));
         Assert.assertNotNull(proxyUpdateControl.getResource().getStatus().getLastApplied());
 
 
@@ -680,7 +680,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertNotNull(proxyUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putDeployment("pulsarname-proxy-setz", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -688,7 +688,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertNotNull(proxyUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putDeployment("pulsarname-proxy-seta", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -698,12 +698,12 @@ public class ProxySetsControllerTest {
 
         // now update
 
-        resolver.putDeployment("pulsarname-proxy-seta", false);
-        resolver.putDeployment("pulsarname-proxy-setz", false);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", false);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", false);
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     setsUpdateStrategy: Parallel
@@ -717,12 +717,12 @@ public class ProxySetsControllerTest {
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
         KubeTestUtil.assertUpdateControlInitializing(proxyUpdateControl);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 2);
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-seta"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-seta"));
         Assert.assertNotNull(proxyUpdateControl.getResource().getStatus().getLastApplied());
 
 
-        resolver.putDeployment("pulsarname-proxy-setz", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -730,7 +730,7 @@ public class ProxySetsControllerTest {
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertNotNull(proxyUpdateControl.getResource().getStatus().getLastApplied());
 
-        resolver.putDeployment("pulsarname-proxy-seta", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-seta", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -743,7 +743,7 @@ public class ProxySetsControllerTest {
     public void testDefineProxySetWithDefaultName() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     sets:
@@ -756,14 +756,14 @@ public class ProxySetsControllerTest {
         KubeTestUtil.assertUpdateControlInitializing(proxyUpdateControl);
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 1);
         // verify order of sets follows the order declared in the spec
-        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsarname-proxy-setz"));
+        Assert.assertNotNull(client.getCreatedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
         ProxyController.ProxySetsLastApplied proxySetsLastApplied =
                 SerializationUtil.readJson(proxyUpdateControl.getResource().getStatus().getLastApplied(),
                         ProxyController.ProxySetsLastApplied.class);
         Assert.assertNotNull(proxySetsLastApplied.getSets().get("setz"));
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putDeployment("pulsarname-proxy-setz", true);
+        resolver.putDeployment("pulsar-spec-1-proxy-setz", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -775,7 +775,7 @@ public class ProxySetsControllerTest {
         Assert.assertNotNull(proxySetsLastApplied.getSets().get("proxy"));
         Assert.assertEquals(client.getDeletedResources().size(), 0);
 
-        resolver.putDeployment("pulsarname-proxy", true);
+        resolver.putDeployment("pulsar-spec-1-proxy", true);
 
         client = new MockKubernetesClient(NAMESPACE, resolver);
         proxyUpdateControl = invokeController(spec, proxyUpdateControl.getResource(), client);
@@ -784,7 +784,7 @@ public class ProxySetsControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     sets:
@@ -799,16 +799,16 @@ public class ProxySetsControllerTest {
         Assert.assertNull(proxySetsLastApplied.getSets().get("proxy"));
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertEquals(client.getCreatedResources(Service.class).size(), 1);
-        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsarname-proxy"));
+        Assert.assertNotNull(client.getCreatedResource(Service.class, "pulsar-spec-1-proxy"));
         Assert.assertEquals(client.getDeletedResources().size(), 4);
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-proxy"));
-        Assert.assertNotNull(client.getDeletedResource(Deployment.class, "pulsarname-proxy"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-proxy"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-proxy-ws"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy"));
+        Assert.assertNotNull(client.getDeletedResource(Deployment.class, "pulsar-spec-1-proxy"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-proxy"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-proxy-ws"));
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:global
                 proxy:
                     replicas: 0
@@ -823,11 +823,11 @@ public class ProxySetsControllerTest {
         Assert.assertNull(proxySetsLastApplied.getSets().get("setz"));
         Assert.assertEquals(client.getCreatedResources(Deployment.class).size(), 0);
         Assert.assertEquals(client.getDeletedResources().size(), 6);
-        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getDeletedResource(Deployment.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-proxy-setz"));
-        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsarname-proxy-setz-ws"));
+        Assert.assertNotNull(client.getDeletedResource(Service.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getDeletedResource(PodDisruptionBudget.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getDeletedResource(Deployment.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-proxy-setz"));
+        Assert.assertNotNull(client.getDeletedResource(ConfigMap.class, "pulsar-spec-1-proxy-setz-ws"));
     }
 
 

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
@@ -61,13 +61,13 @@ import org.testng.annotations.Test;
 public class ZooKeeperControllerTest {
 
     static final String NAMESPACE = "ns";
-    static final String CLUSTER_NAME = "pulsarname";
+    static final String CLUSTER_NAME = "pulsar-spec-1";
 
     @Test
     public void testDefaults() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     image: apachepulsar/pulsar:2.10.2
                 """;
 
@@ -85,16 +85,16 @@ public class ZooKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
-                          name: pulsarname-zookeeper
+                          name: pulsar-spec-1-zookeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: ZooKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         data:
                           PULSAR_EXTRA_OPTS: -Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info
                           PULSAR_LOG_LEVEL: info
@@ -114,25 +114,25 @@ public class ZooKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
-                          name: pulsarname-zookeeper
+                          name: pulsar-spec-1-zookeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: ZooKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           podManagementPolicy: Parallel
                           replicas: 3
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: zookeeper
-                          serviceName: pulsarname-zookeeper
+                          serviceName: pulsar-spec-1-zookeeper
                           template:
                             metadata:
                               annotations:
@@ -140,7 +140,7 @@ public class ZooKeeperControllerTest {
                                 prometheus.io/scrape: "true"
                               labels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: zookeeper
                             spec:
                               affinity:
@@ -149,7 +149,7 @@ public class ZooKeeperControllerTest {
                                   - labelSelector:
                                       matchLabels:
                                         app: pulsar
-                                        cluster: pulsarname
+                                        cluster: pulsar-spec-1
                                         component: zookeeper
                                     topologyKey: kubernetes.io/hostname
                               containers:
@@ -160,10 +160,10 @@ public class ZooKeeperControllerTest {
                                 - -c
                                 env:
                                 - name: ZOOKEEPER_SERVERS
-                                  value: "pulsarname-zookeeper-0,pulsarname-zookeeper-1,pulsarname-zookeeper-2"
+                                  value: "pulsar-spec-1-zookeeper-0,pulsar-spec-1-zookeeper-1,pulsar-spec-1-zookeeper-2"
                                 envFrom:
                                 - configMapRef:
-                                    name: pulsarname-zookeeper
+                                    name: pulsar-spec-1-zookeeper
                                 image: apachepulsar/pulsar:2.10.2
                                 imagePullPolicy: IfNotPresent
                                 livenessProbe:
@@ -175,7 +175,7 @@ public class ZooKeeperControllerTest {
                                   initialDelaySeconds: 20
                                   periodSeconds: 30
                                   timeoutSeconds: 30
-                                name: pulsarname-zookeeper
+                                name: pulsar-spec-1-zookeeper
                                 ports:
                                 - containerPort: 2181
                                   name: client
@@ -198,7 +198,7 @@ public class ZooKeeperControllerTest {
                                     memory: 1Gi
                                 volumeMounts:
                                 - mountPath: /pulsar/data
-                                  name: pulsarname-zookeeper-data
+                                  name: pulsar-spec-1-zookeeper-data
                               dnsConfig:
                                 options:
                                 - name: ndots
@@ -214,9 +214,9 @@ public class ZooKeeperControllerTest {
                             metadata:
                               labels:
                                 app: pulsar
-                                cluster: pulsarname
+                                cluster: pulsar-spec-1
                                 component: zookeeper
-                              name: pulsarname-zookeeper-data
+                              name: pulsar-spec-1-zookeeper-data
                             spec:
                               accessModes:
                               - ReadWriteOnce
@@ -238,16 +238,16 @@ public class ZooKeeperControllerTest {
                             service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
-                          name: pulsarname-zookeeper
+                          name: pulsar-spec-1-zookeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: ZooKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           clusterIP: None
                           ports:
@@ -260,7 +260,7 @@ public class ZooKeeperControllerTest {
                           publishNotReadyAddresses: true
                           selector:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
                         """);
 
@@ -275,16 +275,16 @@ public class ZooKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
-                          name: pulsarname-zookeeper-ca
+                          name: pulsar-spec-1-zookeeper-ca
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: ZooKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           ports:
                           - name: server
@@ -295,7 +295,7 @@ public class ZooKeeperControllerTest {
                             port: 2181
                           selector:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
                             """);
 
@@ -310,22 +310,22 @@ public class ZooKeeperControllerTest {
                         metadata:
                           labels:
                             app: pulsar
-                            cluster: pulsarname
+                            cluster: pulsar-spec-1
                             component: zookeeper
-                          name: pulsarname-zookeeper
+                          name: pulsar-spec-1-zookeeper
                           namespace: ns
                           ownerReferences:
                           - apiVersion: kaap.oss.datastax.com/v1alpha1
                             kind: ZooKeeper
                             blockOwnerDeletion: true
                             controller: true
-                            name: pulsarname-cr
+                            name: pulsar-spec-1-cr
                         spec:
                           maxUnavailable: 1
                           selector:
                             matchLabels:
                               app: pulsar
-                              cluster: pulsarname
+                              cluster: pulsar-spec-1
                               component: zookeeper
                             """);
     }
@@ -334,7 +334,7 @@ public class ZooKeeperControllerTest {
     public void testImage() throws Exception {
         String spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent
@@ -359,7 +359,7 @@ public class ZooKeeperControllerTest {
 
         spec = """
                 global:
-                    name: pulsarname
+                    name: pulsar-spec-1
                     persistence: false
                     image: apachepulsar/pulsar:global
                     imagePullPolicy: IfNotPresent

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperJobTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperJobTest.java
@@ -65,7 +65,7 @@ public class ZooKeeperJobTest {
             pulsarClusterSpec.getZookeeper().applyDefaults(pulsarClusterSpec.getGlobalSpec());
 
 
-            final String clusterName = pulsarClusterSpec.getGlobal().getName();
+            final String clusterSpecName = pulsarClusterSpec.getGlobal().getName();
 
             server = new KubernetesServer(false);
             server.before();
@@ -81,7 +81,7 @@ public class ZooKeeperJobTest {
 
             server.expect()
                     .delete()
-                    .withPath("/apis/batch/v1/namespaces/ns/jobs/%s-zookeeper-metadata".formatted(clusterName))
+                    .withPath("/apis/batch/v1/namespaces/ns/jobs/%s-zookeeper-metadata".formatted(clusterSpecName))
                     .andReply(HttpURLConnection.HTTP_OK, recordedRequest -> {
                         MockServer.this.ops.add(new Op("DELETE"));
                         return null;
@@ -96,7 +96,7 @@ public class ZooKeeperJobTest {
             } else {
                 currentJob = new JobBuilder()
                         .withNewMetadata()
-                        .withName("%s-zookeeper-metadata".formatted(clusterName))
+                        .withName("%s-zookeeper-metadata".formatted(clusterSpecName))
                         .endMetadata()
                         .withNewStatus()
                         .withSucceeded(currentJobState == CurrentJobState.Running ? 0 : 1)
@@ -106,7 +106,7 @@ public class ZooKeeperJobTest {
 
             server.expect()
                     .get()
-                    .withPath("/apis/batch/v1/namespaces/ns/jobs/%s-zookeeper-metadata".formatted(clusterName))
+                    .withPath("/apis/batch/v1/namespaces/ns/jobs/%s-zookeeper-metadata".formatted(clusterSpecName))
                     .andReturn(HttpURLConnection.HTTP_OK, currentJob)
                     .always();
         }


### PR DESCRIPTION
This adds an option to set the pulsar `clusterName` as defined in the `broker.conf` file separately from the `name` field used as a prefix to pulsar Kubernetes resources.  These two values have a different scope: the k8s resource prefix is scoped within the cluster, while the clusterName has to be unique among other clusters involved in georeplication, so it seems like it makes sense to have two separate values for these.

Fixes #143