### PR TITLE
fix a couple of compiler warnings

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java
@@ -37,6 +37,7 @@ import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
 
@@ -44,6 +45,7 @@ import org.apache.commons.lang3.ObjectUtils;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(callSuper = false)
 public class GlobalSpec extends ValidableSpec<GlobalSpec> implements WithDefaults {
 
 
@@ -150,7 +152,6 @@ public class GlobalSpec extends ValidableSpec<GlobalSpec> implements WithDefault
         @JsonPropertyDescription("Indicates if an already existing storage class should be used.")
         private String existingStorageClassName;
     }
-
 
     @NotNull
     @Required


### PR DESCRIPTION
- [WARNING] kaap/operator/src/main/java/com/datastax/oss/kaap/crds/GlobalSpec.java:[42,1] Generating equals/hashCode implementation but without a call to superclass, even though this class does not extend java.lang.Object. If this is intentional, add '@EqualsAndHashCode(callSuper=false)' to your type.

- ~~[WARNING] Annotation: javax.validation.constraints.NotNull on property: getName is deprecated. Please use: io.fabric8.generator.annotation.Required instead~~
  It seems that this one is intentional https://github.com/fabric8io/kubernetes-client/issues/4577
  And it will be fixed by #146 