### PR TITLE
upgrade quarkus-sdk 5.0.1->5.1.4

### DIFF
--- a/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BookKeeperAutoscalerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/autoscaler/BookKeeperAutoscalerTest.java
@@ -190,7 +190,7 @@ public class BookKeeperAutoscalerTest {
                         .get()
                         .withPath("/api/v1/namespaces/ns/pods/%s".formatted(podName))
                         .andReturn(HttpURLConnection.HTTP_OK, pod)
-                        .once();
+                        .always();
             }
             final PodList podList = new PodListBuilder()
                     .withItems(pods)

--- a/operator/src/test/java/com/datastax/oss/kaap/autoscaler/broker/LoadReportResourceUsageSourceTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/autoscaler/broker/LoadReportResourceUsageSourceTest.java
@@ -47,7 +47,6 @@ public class LoadReportResourceUsageSourceTest {
     @Builder(setterPrefix = "with")
     public static class MockServer implements AutoCloseable {
 
-
         private PulsarClusterSpec pulsarClusterSpec;
         private BiConsumer<Pod, MockServer> podConsumer;
 
@@ -93,6 +92,11 @@ public class LoadReportResourceUsageSourceTest {
                         .build();
                 podConsumer.accept(pod, this);
                 pods.add(pod);
+                server.expect()
+                        .get()
+                        .withPath("/api/v1/namespaces/ns/pods/%s".formatted(podName))
+                        .andReturn(HttpURLConnection.HTTP_OK, pod)
+                        .once();
             }
 
             final PodList podList = new PodListBuilder()

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-sdk.version>5.0.1</quarkus-sdk.version>
+        <quarkus-sdk.version>5.1.4</quarkus-sdk.version>
         <!-- kubernetes-client.version must matches the imported version by quarkus-sdk -->
-        <kubernetes-client.version>6.2.0</kubernetes-client.version>
+        <kubernetes-client.version>6.3.1</kubernetes-client.version>
         <testng.version>7.7.0</testng.version>
         <mockito-core.version>4.10.0</mockito-core.version>
         <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
I created this before seeing #102, however, it should be fine to merge this one before that one get merged.  That's a bit bigger upgrade so it involves more significant changes.

There was a change to the `exec` operation in the upstream kubernetes-client (https://github.com/fabric8io/kubernetes-client/pull/4505) where it first calls `get` on the pod to get the container names, so this changes the mock server to expect this extra call.