### PR TITLE
tests: disable multi-node integration test

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -64,9 +64,9 @@ jobs:
             group: helm-tls
             num_agents: 0
             setup_helm: "true"
-          - name: Multi nodes
-            group: multi-nodes
-            num_agents: 1
+#          - name: Multi nodes
+#            group: multi-nodes
+#            num_agents: 1
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>tests</artifactId>
 
     <properties>
-        <kindcontainer.version>1.4.0</kindcontainer.version>
+        <kindcontainer.version>1.4.3</kindcontainer.version>
 
     </properties>
     <dependencies>


### PR DESCRIPTION
I think this requires a larger disk than what is available on the default
github action runners.  Disable this test on github ci until we can set
up appropriate runner instances.

This also upgrades the kindcontainer dependency.
Fixes #147 