### PR TITLE
Add resources templating option to kaap operator deployment

### DIFF
--- a/helm/kaap/templates/operator.yaml
+++ b/helm/kaap/templates/operator.yaml
@@ -59,6 +59,10 @@ spec:
                 name: {{ include "kaap.name" . }}
           image: {{ .Values.operator.image }}
           imagePullPolicy: {{ .Values.operator.imagePullPolicy }}
+          {{- if .Values.operator.resources }}
+          resources:
+            {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- end }}          
           livenessProbe:
             failureThreshold: {{ .Values.operator.livenessProbe.failureThreshold }}
             httpGet:

--- a/helm/kaap/values.yaml
+++ b/helm/kaap/values.yaml
@@ -39,7 +39,9 @@ operator:
   enabled: true
   image: datastax/kaap:0.2.0
   imagePullPolicy: IfNotPresent
+  resources: {}
   replicas: 1
+  
   livenessProbe:
     failureThreshold: 3
     periodSeconds: 30


### PR DESCRIPTION
For our cluster operation and complying to security standards its mandatory being able to configure pod resources. 

Some standards for resources configuration we need to comply:
- OWASP API Security Top 10-API7:2019-Security Misconfiguration
- CWE Top 25 Most Dangerous Software Weaknesses-cwe-top-25
- OWASP Docker Top 10 2018-D07 - Resource Protection
- CIS Docker - Level 1-5.10

Because we should be flexible to applying different patterns for resource-requests and -limits I templated the full `resources:` block depending on values configuration and not the individual values.
E.g. on pattern for [requests and limits](https://home.robusta.dev/blog/kubernetes-memory-limit) 
