### PR TITLE
Use pulsar_subscription_msg_rate_redeliver in topic charts

### DIFF
--- a/helm/kaap-stack/grafana-dashboards/topic.json
+++ b/helm/kaap-stack/grafana-dashboards/topic.json
@@ -1411,7 +1411,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "pulsar_consumer_msg_rate_redeliver{cluster=~\"$cluster\", namespace=~\"$tenant.+\", namespace=~\"$namespace\", topic=~\"$topic\"}",
+          "expr": "pulsar_subscription_msg_rate_redeliver{cluster=~\"$cluster\", namespace=~\"$tenant.+\", namespace=~\"$namespace\", topic=~\"$topic\"}",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,


### PR DESCRIPTION
The current pulsar_consumer_msg_rate_redeliver metric is not always enabled, we should use pulsar_subscription_msg_rate_redeliver instead.