### PR TITLE
support ZooKeeper 3.9.2 tls 1.3

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -65,6 +65,10 @@ jobs:
             group: helm-tls
             num_agents: 0
             setup_helm: "true"
+          - name: Helm (TLS) Pulsar 3
+            group: helm-tls-pulsar3
+            num_agents: 0
+            setup_helm: "true"
           - name: Helm Kafka (TLS)
             group: helm-tls-kafka
             num_agents: 0

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14112,6 +14112,13 @@ Configuration for the rack auto configuration.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>additionalZookeeperClientConfig</b></td>
+        <td>JSON</td>
+        <td>
+          Additional configuration for the zookeeper client.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>enabled</b></td>
         <td>boolean</td>
         <td>

--- a/helm/examples/kafka/values.yaml
+++ b/helm/examples/kafka/values.yaml
@@ -17,7 +17,7 @@
 
 kaap:
   operator:
-    enabled: false
+    enabled: true
   cluster:
     create: true
     spec:

--- a/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
@@ -598,6 +598,9 @@ spec:
                         description: Period for the schedule of the monitoring thread.
                         minimum: 1000.0
                         type: integer
+                      additionalZookeeperClientConfig:
+                        description: Additional configuration for the zookeeper client.
+                        x-kubernetes-preserve-unknown-fields: true
                       enabled:
                         description: Enable rack configuration monitoring.
                         type: boolean

--- a/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
@@ -15795,6 +15795,9 @@ spec:
                         description: Period for the schedule of the monitoring thread.
                         minimum: 1000.0
                         type: integer
+                      additionalZookeeperClientConfig:
+                        description: Additional configuration for the zookeeper client.
+                        x-kubernetes-preserve-unknown-fields: true
                       enabled:
                         description: Enable rack configuration monitoring.
                         type: boolean

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/racks/client/ZkClientRackClientFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/racks/client/ZkClientRackClientFactory.java
@@ -22,14 +22,16 @@ import com.datastax.oss.kaap.crds.bookkeeper.BookKeeperFullSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.runtime.LaunchMode;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog
-public class ZkClientRackClientFactory implements BkRackClientFactory{
+public class ZkClientRackClientFactory implements BkRackClientFactory {
 
     private final Map<String, ZkClientRackClient> zkClients = new ConcurrentHashMap<>();
     private final KubernetesClient client;
@@ -40,7 +42,7 @@ public class ZkClientRackClientFactory implements BkRackClientFactory{
 
     @Override
     public BkRackClient newBkRackClient(String namespace, BookKeeperFullSpec newSpec,
-                                               BookKeeperAutoRackConfig autoRackConfig) {
+                                        BookKeeperAutoRackConfig autoRackConfig) {
         final String zkConnectString = getZkServers(namespace, newSpec);
 
         if (!autoRackConfig.getEnabled()) {
@@ -61,15 +63,15 @@ public class ZkClientRackClientFactory implements BkRackClientFactory{
 
         final ZkClientRackClient zkClient =
                 zkClients.computeIfAbsent(zkConnectString,
-                        (k) -> newZkRackClient(k, newSpec.getGlobalSpec(), namespace));
+                        (k) -> newZkRackClient(k, newSpec.getGlobalSpec(), namespace, autoRackConfig.getAdditionalZookeeperClientConfig()));
         return zkClient;
     }
 
 
-    private ZkClientRackClient newZkRackClient(String zkConnectString, GlobalSpec globalSpec, String namespace) {
+    private ZkClientRackClient newZkRackClient(String zkConnectString, GlobalSpec globalSpec, String namespace, Map<String, String> additionalZkClientConfig) {
         final boolean tlsEnabledOnZooKeeper = BaseResourcesFactory.isTlsEnabledOnZooKeeper(globalSpec);
         if (!tlsEnabledOnZooKeeper) {
-            return ZkClientRackClient.plainClient(zkConnectString);
+            return ZkClientRackClient.plainClient(zkConnectString, additionalZkClientConfig);
         }
         final String tlsSecretNameForZookeeper = BaseResourcesFactory.getTlsSecretNameForZookeeper(globalSpec);
         final Secret secret = client.secrets()
@@ -89,7 +91,7 @@ public class ZkClientRackClientFactory implements BkRackClientFactory{
         if (caCert != null) {
             caCert = new String(Base64.getDecoder().decode(caCert), StandardCharsets.UTF_8);
         }
-        return ZkClientRackClient.sslClient(zkConnectString, privateKey, serverCert, caCert);
+        return ZkClientRackClient.sslClient(zkConnectString, privateKey, serverCert, caCert, additionalZkClientConfig);
     }
 
     protected String getZkServers(String namespace, BookKeeperFullSpec newSpec) {

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/racks/client/ZkClientRackClientFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/racks/client/ZkClientRackClientFactory.java
@@ -22,12 +22,10 @@ import com.datastax.oss.kaap.crds.bookkeeper.BookKeeperFullSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.quarkus.runtime.LaunchMode;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -197,6 +197,9 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
             data.put("serverCnxnFactory", "org.apache.zookeeper.server.NettyServerCnxnFactory");
             data.put("secureClientPort", "2281");
             data.put("sslQuorum", "true");
+            // TLSv1.2 is backward compatible with ZK < 3.9.2
+            data.put("ssl.protocol", "TLSv1.2");
+            data.put("ssl.quorum.protocol", "TLSv1.2");
         }
         appendConfigData(data, spec.getConfig());
 

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoRackConfig.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoRackConfig.java
@@ -19,12 +19,11 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.generator.annotation.SchemaFrom;
 import io.fabric8.generator.annotation.Min;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.Map;
 
 @Builder
 @Data

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoRackConfig.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/bookkeeper/BookKeeperAutoRackConfig.java
@@ -16,11 +16,15 @@
 package com.datastax.oss.kaap.crds.bookkeeper;
 
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.fabric8.crd.generator.annotation.SchemaFrom;
 import io.fabric8.generator.annotation.Min;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.Map;
 
 @Builder
 @Data
@@ -34,4 +38,8 @@ public class BookKeeperAutoRackConfig {
     @javax.validation.constraints.Min(1000)
     @JsonPropertyDescription("Period for the schedule of the monitoring thread.")
     Long periodMs;
+    @JsonPropertyDescription("Additional configuration for the zookeeper client.")
+    @SchemaFrom(type = JsonNode.class)
+    Map<String, String> additionalZookeeperClientConfig;
+
 }

--- a/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
+++ b/operator/src/test/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperControllerTest.java
@@ -479,6 +479,8 @@ public class ZooKeeperControllerTest {
         expectedData.put("PULSAR_PREFIX_serverCnxnFactory", "org.apache.zookeeper.server.NettyServerCnxnFactory");
         expectedData.put("PULSAR_PREFIX_secureClientPort", "2281");
         expectedData.put("PULSAR_PREFIX_sslQuorum", "true");
+        expectedData.put("PULSAR_PREFIX_ssl.protocol", "TLSv1.2");
+        expectedData.put("PULSAR_PREFIX_ssl.quorum.protocol", "TLSv1.2");
 
         final Map<String, String> data = createdResource.getResource().getData();
         Assert.assertEquals(data, expectedData);

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,8 @@
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <curator.version>5.4.0</curator.version>
+        <curator.version>5.6.0</curator.version>
+        <zookkeeper.version>3.9.2</zookkeeper.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -159,6 +160,11 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-test</artifactId>
                 <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookkeeper.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <kubernetes-client.version>6.3.1</kubernetes-client.version>
         <testng.version>7.7.0</testng.version>
         <mockito-core.version>4.10.0</mockito-core.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.32</lombok.version>
         <spotbugs-maven-plugin.version>4.7.2.1</spotbugs-maven-plugin.version>
         <spotbugs.version>4.7.2</spotbugs.version>
         <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BaseK8sEnvTest.java
@@ -90,7 +90,10 @@ public abstract class BaseK8sEnvTest {
             "datastax/kaap:latest-dev");
 
     public static final String PULSAR_IMAGE = System.getProperty("kaap.tests.pulsar.image",
-            "docker.io/datastax/lunastreaming-all:2.10_3.4");
+            "docker.io/datastax/lunastreaming-all:2.10_5.1");
+
+    public static final String PULSAR3_IMAGE = System.getProperty("kaap.tests.pulsar.image",
+            "docker.io/datastax/lunastreaming-all:3.1_4.0");
 
     public static final boolean USE_EXISTING_ENV = Boolean.getBoolean("kaap.tests.env.existing");
 

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/BasePulsarClusterTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/BasePulsarClusterTest.java
@@ -87,11 +87,15 @@ public abstract class BasePulsarClusterTest extends BaseK8sEnvTest {
     }
 
     protected PulsarClusterSpec getDefaultPulsarClusterSpecs() {
+        return getDefaultPulsarClusterSpecs(false);
+    }
+
+    protected PulsarClusterSpec getDefaultPulsarClusterSpecs(boolean pulsar3) {
         final PulsarClusterSpec defaultSpecs = new PulsarClusterSpec();
         defaultSpecs.setGlobal(GlobalSpec.builder()
                 .name(DEFAULT_PULSAR_CLUSTER_NAME)
                 .persistence(true)
-                .image(PULSAR_IMAGE)
+                .image(pulsar3 ? PULSAR3_IMAGE : PULSAR_IMAGE)
                 .imagePullPolicy("IfNotPresent")
                 .storage(GlobalSpec.GlobalStorageConfig.builder()
                         .existingStorageClassName(env.getStorageClass())

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/Pulsar2TlsTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/Pulsar2TlsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.kaap.tests.helm;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "helm-tls")
+public class Pulsar2TlsTest extends TlsTest {
+
+    @Test
+    public void testPerComponents() throws Exception {
+        test(true, false);
+    }
+
+    @Test
+    public void testGlobal() throws Exception {
+        test(false, false);
+
+    }
+}

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/Pulsar3TlsTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/Pulsar3TlsTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.kaap.tests.helm;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+@Test(groups = "helm-tls-pulsar3")
+public class Pulsar3TlsTest extends TlsTest {
+    @Test
+    public void testPerComponents() throws Exception {
+        test(true, true);
+    }
+
+    @Test
+    public void testGlobal() throws Exception {
+        test(false, true);
+
+    }
+}

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
@@ -27,16 +27,21 @@ public class TlsTest extends BaseHelmTest {
 
     @Test
     public void testPerComponents() throws Exception {
-        test(true);
+        test(true, false);
     }
 
     @Test
     public void testGlobal() throws Exception {
-        test(false);
+        test(false, false);
 
     }
 
-    private void test(boolean perComponentCerts) throws Exception {
+    @Test
+    public void testPulsar3x() throws Exception {
+        test(true, true);
+    }
+
+    private void test(boolean perComponentCerts, boolean pulsar3) throws Exception {
         try {
             applyCertManagerCRDs();
             helmInstall(Chart.STACK, """
@@ -52,7 +57,7 @@ public class TlsTest extends BaseHelmTest {
                     """.formatted(OPERATOR_IMAGE, namespace));
             awaitOperatorRunning();
 
-            final PulsarClusterSpec specs = getDefaultPulsarClusterSpecs();
+            final PulsarClusterSpec specs = getDefaultPulsarClusterSpecs(pulsar3);
             if (perComponentCerts) {
                 specs.getGlobal()
                         .setTls(TlsConfig.builder()

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
@@ -22,26 +22,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.Test;
 
 @Slf4j
-@Test(groups = "helm-tls")
-public class TlsTest extends BaseHelmTest {
+public abstract class TlsTest extends BaseHelmTest {
 
-    @Test
-    public void testPerComponents() throws Exception {
-        test(true, false);
-    }
-
-    @Test
-    public void testGlobal() throws Exception {
-        test(false, false);
-
-    }
-
-    @Test
-    public void testPulsar3x() throws Exception {
-        test(true, true);
-    }
-
-    private void test(boolean perComponentCerts, boolean pulsar3) throws Exception {
+    protected void test(boolean perComponentCerts, boolean pulsar3) throws Exception {
         try {
             applyCertManagerCRDs();
             helmInstall(Chart.STACK, """

--- a/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
+++ b/tests/src/test/java/com/datastax/oss/kaap/tests/helm/TlsTest.java
@@ -19,7 +19,6 @@ import com.datastax.oss.kaap.crds.cluster.PulsarCluster;
 import com.datastax.oss.kaap.crds.cluster.PulsarClusterSpec;
 import com.datastax.oss.kaap.crds.configs.tls.TlsConfig;
 import lombok.extern.slf4j.Slf4j;
-import org.testng.annotations.Test;
 
 @Slf4j
 public abstract class TlsTest extends BaseHelmTest {


### PR DESCRIPTION
ZooKeeper 3.9.2 comes with TLS 1.3 enabled by default (if jdk >= 17).
Since the operator uses a zk client to connect to it, it's better to set tls 1.2 explictly in the ZK configuration to not be dependent on the JDK version 