### PR TITLE
Added JAVA_OPTS as an env variable to allow additional customization by appending existing options

### DIFF
--- a/helm/kaap-stack/values.yaml
+++ b/helm/kaap-stack/values.yaml
@@ -397,3 +397,5 @@ bkvm:
         value: pulsar
       - name: BKVM_user.1.role
         value: Admin
+      - name: JAVA_OPTS
+        value: "-Xmx1g -Xms1g -XX:+UseContainerSupport -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"

--- a/helm/kaap-stack/values.yaml
+++ b/helm/kaap-stack/values.yaml
@@ -398,4 +398,4 @@ bkvm:
       - name: BKVM_user.1.role
         value: Admin
       - name: JAVA_OPTS
-        value: "-Xmx1g -Xms1g -XX:+UseContainerSupport -XX:InitialRAMPercentage=70.0 -XX:MaxRAMPercentage=70.0"
+        value: "-Xmx3g -Xms3g"


### PR DESCRIPTION
This pull request adds a env var JAVA_OPTS to ensure that additional JVM options (such as changing heap space, direct memory) can be appended to the existing settings.

Related PR: [BKVM fix](https://github.com/diennea/bookkeeper-visual-manager/pull/141)