### PR TITLE
Zookeeper metrics port registration

### DIFF
--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -62,6 +62,7 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
     public static final int DEFAULT_LEADER_ELECTION_PORT = 3888;
     public static final int DEFAULT_CLIENT_PORT = 2181;
     public static final int DEFAULT_CLIENT_TLS_PORT = 2281;
+    public static final int DEFAULT_METRICS_PORT = 8000;
     public static final String ENV_ZOOKEEPER_SERVERS = "ZOOKEEPER_SERVERS";
     public static final List<String> DEFAULT_ENV = List.of("ZOOKEEPER_SERVERS");
 
@@ -309,6 +310,10 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
                                 new ContainerPortBuilder()
                                         .withName("leader-election")
                                         .withContainerPort(DEFAULT_LEADER_ELECTION_PORT)
+                                        .build(),
+                                new ContainerPortBuilder()
+                                        .withName("metrics")
+                                        .withContainerPort(DEFAULT_METRICS_PORT)
                                         .build()
                         ))
                         .withEnv(env)


### PR DESCRIPTION
The Zookeeper container is currently not configured to register the metrics port, which prevents the creation of a PodMonitor for monitoring Zookeeper metrics. This issue is a critical blocker, as it limits the ability to scrape and collect metrics from the Zookeeper pods effectively.

This PR addresses the problem by ensuring that the Zookeeper container properly exposes and registers the metrics port, enabling the integration with Prometheus via a PodMonitor.