### PR TITLE
LS-1358: upgraded the default lunastreaming version in kaap chart to 4.0_3.6

### DIFF
--- a/helm/kaap/values.yaml
+++ b/helm/kaap/values.yaml
@@ -69,6 +69,6 @@ cluster:
   spec:
     global:
       name: pulsar
-      image: datastax/lunastreaming-all:2.10_3.1
+      image: datastax/lunastreaming-all:4.0_3.6
       storage:
         existingStorageClassName: default


### PR DESCRIPTION
This upgrades the default lunastreaming version in kaap chart from 2.10_3.1 to 4.0_3.6
[LS-1358](https://datastax.jira.com/jira/software/projects/LS/boards/597?selectedIssue=LS-1358)

[LS-1358]: https://datastax.jira.com/browse/LS-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ