### PR TITLE
AS-5316: Add support for minReadySeconds to all KAAP CRs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -235,6 +235,13 @@ Resource Types:
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#pulsarclusterspecautorecoverynodeaffinity">nodeAffinity</a></b></td>
         <td>object</td>
         <td>
@@ -6015,6 +6022,13 @@ Subset of PodSecurityContext for basic UID, GID, and volume access control.
         <td>map[string]string</td>
         <td>
           Match labels selectors to add to each pod.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -11833,6 +11847,13 @@ Subset of PodSecurityContext for basic UID, GID, and volume access control.
         <td>map[string]string</td>
         <td>
           Match labels selectors to add to each pod.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -18990,6 +19011,13 @@ Service configuration.
         <td>map[string]string</td>
         <td>
           Match labels selectors to add to each pod.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -31555,6 +31583,13 @@ Indicates if a StorageClass is used. The operator will create the StorageClass i
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#pulsarclusterspecbrokernodeaffinity">nodeAffinity</a></b></td>
         <td>object</td>
         <td>
@@ -38726,6 +38761,13 @@ Service configuration.
         <td>map[string]string</td>
         <td>
           Match labels selectors to add to each pod.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -51137,6 +51179,13 @@ Update strategy for the StatefulSet.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#pulsarclusterspecfunctionsworkernodeaffinity">nodeAffinity</a></b></td>
         <td>object</td>
         <td>
@@ -63421,6 +63470,13 @@ TLS configurations related to the ZooKeeper component.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#pulsarclusterspecproxynodeaffinity">nodeAffinity</a></b></td>
         <td>object</td>
         <td>
@@ -70480,6 +70536,13 @@ Service configuration.
         <td>map[string]string</td>
         <td>
           Match labels selectors to add to each pod.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -83097,6 +83160,13 @@ Resources requirements.
         <td>object</td>
         <td>
           Configuration about the job that initializes the Pulsar cluster creating the needed ZooKeeper nodes.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>minReadySeconds</b></td>
+        <td>integer</td>
+        <td>
+          Min seconds to wait before considering the pod as ready.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/helm/kaap/crds/autorecoveries.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/autorecoveries.kaap.oss.datastax.com-v1.yml
@@ -671,6 +671,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:

--- a/helm/kaap/crds/bastions.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bastions.kaap.oss.datastax.com-v1.yml
@@ -671,6 +671,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:

--- a/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/bookkeepers.kaap.oss.datastax.com-v1.yml
@@ -1452,6 +1452,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -3133,6 +3137,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:

--- a/helm/kaap/crds/brokers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/brokers.kaap.oss.datastax.com-v1.yml
@@ -1452,6 +1452,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -3154,6 +3158,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:

--- a/helm/kaap/crds/functionsworkers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/functionsworkers.kaap.oss.datastax.com-v1.yml
@@ -1420,6 +1420,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:

--- a/helm/kaap/crds/proxies.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/proxies.kaap.oss.datastax.com-v1.yml
@@ -2276,6 +2276,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -3911,6 +3915,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:

--- a/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/pulsarclusters.kaap.oss.datastax.com-v1.yml
@@ -670,6 +670,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -2012,6 +2016,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -4140,6 +4148,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -5821,6 +5833,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:
@@ -8830,6 +8846,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -10532,6 +10552,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:
@@ -13418,6 +13442,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -16507,6 +16535,10 @@ spec:
                       type: "string"
                     description: "Match labels selectors to add to each pod."
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:
@@ -18142,6 +18174,10 @@ spec:
                             type: "string"
                           description: "Match labels selectors to add to each pod."
                           type: "object"
+                        minReadySeconds:
+                          description: "Min seconds to wait before considering the\
+                            \ pod as ready."
+                          type: "integer"
                         nodeAffinity:
                           description: "Node affinity configuration."
                           properties:
@@ -21192,6 +21228,10 @@ spec:
                           \ execution. Default value is 60."
                         type: "integer"
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:

--- a/helm/kaap/crds/zookeepers.kaap.oss.datastax.com-v1.yml
+++ b/helm/kaap/crds/zookeepers.kaap.oss.datastax.com-v1.yml
@@ -2342,6 +2342,10 @@ spec:
                           \ execution. Default value is 60."
                         type: "integer"
                     type: "object"
+                  minReadySeconds:
+                    description: "Min seconds to wait before considering the pod as\
+                      \ ready."
+                    type: "integer"
                   nodeAffinity:
                     description: "Node affinity configuration."
                     properties:

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/AutorecoverySpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/AutorecoverySpecGenerator.java
@@ -96,6 +96,7 @@ public class AutorecoverySpecGenerator extends BaseSpecGenerator<AutorecoverySpe
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(deploymentSpec.getReplicas())
+                .minReadySeconds(deploymentSpec.getMinReadySeconds())
                 .nodeAffinity(nodeAffinity)
                 .labels(deployment.getMetadata().getLabels())
                 .podLabels(deploymentSpec.getTemplate().getMetadata().getLabels())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BastionSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BastionSpecGenerator.java
@@ -98,6 +98,7 @@ public class BastionSpecGenerator extends BaseSpecGenerator<BastionSpec> {
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(deploymentSpec.getReplicas())
+                .minReadySeconds(deploymentSpec.getMinReadySeconds())
                 .nodeAffinity(nodeAffinity)
                 .labels(deployment.getMetadata().getLabels())
                 .podLabels(deploymentSpec.getTemplate().getMetadata().getLabels())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BookKeeperSetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BookKeeperSetSpecGenerator.java
@@ -117,6 +117,7 @@ public class BookKeeperSetSpecGenerator extends BaseSpecGenerator<BookKeeperSetS
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(statefulSetSpec.getReplicas())
+                .minReadySeconds(statefulSetSpec.getMinReadySeconds())
                 .probes(createProbeConfig(container))
                 .nodeAffinity(nodeAffinity)
                 .pdb(podDisruptionBudgetConfig)

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BrokerSetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/BrokerSetSpecGenerator.java
@@ -120,6 +120,7 @@ public class BrokerSetSpecGenerator extends BaseSpecGenerator<BrokerSetSpec> {
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(statefulSetSpec.getReplicas())
+                .minReadySeconds(statefulSetSpec.getMinReadySeconds())
                 .probes(createBrokerProbeConfig(container))
                 .nodeAffinity(nodeAffinity)
                 .pdb(podDisruptionBudgetConfig)

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/FunctionsWorkerSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/FunctionsWorkerSpecGenerator.java
@@ -121,6 +121,7 @@ public class FunctionsWorkerSpecGenerator extends BaseSpecGenerator<FunctionsWor
                 .imagePullPolicy(mainContainer.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(statefulSetSpec.getReplicas())
+                .minReadySeconds(statefulSetSpec.getMinReadySeconds())
                 .nodeAffinity(nodeAffinity)
                 .probes(createProbeConfig(mainContainer))
                 .labels(statefulSet.getMetadata().getLabels())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ProxySetSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ProxySetSpecGenerator.java
@@ -122,6 +122,7 @@ public class ProxySetSpecGenerator extends BaseSpecGenerator<ProxySetSpec> {
                 .imagePullPolicy(mainContainer.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(deploymentSpec.getReplicas())
+                .minReadySeconds(deploymentSpec.getMinReadySeconds())
                 .nodeAffinity(nodeAffinity)
                 .probes(createProbeConfig(mainContainer))
                 .labels(deployment.getMetadata().getLabels())

--- a/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ZooKeeperSpecGenerator.java
+++ b/migration-tool/src/main/java/com/datastax/oss/kaap/migrationtool/specs/ZooKeeperSpecGenerator.java
@@ -114,6 +114,7 @@ public class ZooKeeperSpecGenerator extends BaseSpecGenerator<ZooKeeperSpec> {
                 .imagePullPolicy(container.getImagePullPolicy())
                 .nodeSelectors(spec.getNodeSelector())
                 .replicas(statefulSetSpec.getReplicas())
+                .minReadySeconds(statefulSetSpec.getMinReadySeconds())
                 .probes(createProbeConfig(container))
                 .nodeAffinity(nodeAffinity)
                 .pdb(podDisruptionBudgetConfig)

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/autorecovery/AutorecoveryResourcesFactory.java
@@ -192,6 +192,7 @@ public class AutorecoveryResourcesFactory extends BaseResourcesFactory<Autorecov
                 .endMetadata()
                 .withNewSpec()
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bastion/BastionResourcesFactory.java
@@ -176,6 +176,7 @@ public class BastionResourcesFactory extends BaseResourcesFactory<BastionSpec> {
                 .endMetadata()
                 .withNewSpec()
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/bookkeeper/BookKeeperResourcesFactory.java
@@ -347,6 +347,7 @@ public class BookKeeperResourcesFactory extends BaseResourcesFactory<BookKeeperS
                 .withNewSpec()
                 .withServiceName(resourceName)
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/broker/BrokerResourcesFactory.java
@@ -410,6 +410,7 @@ public class BrokerResourcesFactory extends BaseResourcesFactory<BrokerSetSpec> 
                 .withNewSpec()
                 .withServiceName(resourceName)
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/function/FunctionsWorkerResourcesFactory.java
@@ -494,6 +494,7 @@ public class FunctionsWorkerResourcesFactory extends BaseResourcesFactory<Functi
                 .withNewSpec()
                 .withServiceName(resourceName)
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/proxy/ProxyResourcesFactory.java
@@ -530,6 +530,7 @@ public class ProxyResourcesFactory extends BaseResourcesFactory<ProxySetSpec> {
                 .endMetadata()
                 .withNewSpec()
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(getMatchLabels(spec.getMatchLabels()))
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/controllers/zookeeper/ZooKeeperResourcesFactory.java
@@ -345,6 +345,7 @@ public class ZooKeeperResourcesFactory extends BaseResourcesFactory<ZooKeeperSpe
                 .withNewSpec()
                 .withServiceName(resourceName)
                 .withReplicas(spec.getReplicas())
+                .withMinReadySeconds(spec.getMinReadySeconds())
                 .withNewSelector()
                 .withMatchLabels(matchLabels)
                 .endSelector()

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/BaseComponentSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/BaseComponentSpec.java
@@ -51,6 +51,8 @@ public abstract class BaseComponentSpec<T> extends ValidableSpec<T> implements W
     private PodDisruptionBudgetConfig pdb;
     @JsonPropertyDescription("Mount additional volumes to the pod.")
     private AdditionalVolumesConfig additionalVolumes;
+    @JsonPropertyDescription(CRDConstants.DOC_MIN_READY_SECONDS)
+    private Integer minReadySeconds;
     @JsonPropertyDescription(CRDConstants.DOC_TOLERATIONS)
     private List<Toleration> tolerations;
     @JsonPropertyDescription(CRDConstants.DOC_NODE_AFFINITY)

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/CRDConstants.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/CRDConstants.java
@@ -46,6 +46,7 @@ public final class CRDConstants {
     public static final String DOC_POD_MATCH_LABELS = "Match labels selectors to add to each pod.";
     public static final String DOC_CONFIG = "Configuration.";
     public static final String DOC_REPLICAS = "Number of desired replicas.";
+    public static final String DOC_MIN_READY_SECONDS = "Min seconds to wait before considering the pod as ready.";
     public static final String DOC_GRACE_PERIOD = "Termination grace period in seconds.";
     public static final String DOC_RESOURCES = "Resources requirements.";
     public static final String DOC_TOLERATIONS = "Pod tolerations.";

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/autorecovery/AutorecoverySpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/autorecovery/AutorecoverySpec.java
@@ -67,6 +67,8 @@ public class AutorecoverySpec extends ValidableSpec<AutorecoverySpec> implements
     protected Map<String, Object> config;
     @JsonPropertyDescription(CRDConstants.DOC_REPLICAS)
     protected Integer replicas;
+    @JsonPropertyDescription(CRDConstants.DOC_MIN_READY_SECONDS)
+    private Integer minReadySeconds;
     @JsonPropertyDescription(CRDConstants.DOC_ANNOTATIONS)
     private Map<String, String> annotations;
     @JsonPropertyDescription(CRDConstants.DOC_POD_ANNOTATIONS)

--- a/operator/src/main/java/com/datastax/oss/kaap/crds/bastion/BastionSpec.java
+++ b/operator/src/main/java/com/datastax/oss/kaap/crds/bastion/BastionSpec.java
@@ -67,6 +67,8 @@ public class BastionSpec extends ValidableSpec<BastionSpec> implements WithDefau
     protected Map<String, Object> config;
     @JsonPropertyDescription(CRDConstants.DOC_REPLICAS)
     protected Integer replicas;
+    @JsonPropertyDescription(CRDConstants.DOC_MIN_READY_SECONDS)
+    private Integer minReadySeconds;
     @JsonPropertyDescription(CRDConstants.DOC_ANNOTATIONS)
     private Map<String, String> annotations;
     @JsonPropertyDescription(CRDConstants.DOC_POD_ANNOTATIONS)


### PR DESCRIPTION
### Changes

- Add support for minReadySeconds to all KAAP CRs
- Update the api-reference.md and all KAAP CRs to include the `minReadySeconds` field